### PR TITLE
Configurable log rate limit

### DIFF
--- a/flags/flags.go
+++ b/flags/flags.go
@@ -1,9 +1,10 @@
 package flags
 
 import (
-	"gopkg.in/alecthomas/kingpin.v2"
 	"os"
 	"strings"
+
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 var (
@@ -21,6 +22,8 @@ var (
 	AvailabilityZone  = kingpin.Flag("availability-zone", "`availability_zone` label for `node_cloud_info` metric").Envar("AVAILABILITY_ZONE").String()
 	InstanceType      = kingpin.Flag("instance-type", "`instance_type` label for `node_cloud_info` metric").Envar("INSTANCE_TYPE").String()
 	InstanceLifeCycle = kingpin.Flag("instance-life-cycle", "`instance_life_cycle` label for `node_cloud_info` metric").Envar("INSTANCE_LIFE_CYCLE").String()
+	LogPerSecond      = kingpin.Flag("log-per-second", "The number of logs per second").Default("10.0").Envar("LOG_PER_SECOND").Float64()
+	LogBurst          = kingpin.Flag("log-burst", "The maximum number of tokens that can be consumed in a single call to allow").Default("100").Envar("LOG_BURST").Int()
 )
 
 func GetString(fl *string) string {

--- a/main.go
+++ b/main.go
@@ -2,6 +2,13 @@ package main
 
 import (
 	"bytes"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+	"path"
+	"runtime"
+	"strings"
+
 	"github.com/coroot/coroot-node-agent/common"
 	"github.com/coroot/coroot-node-agent/containers"
 	"github.com/coroot/coroot-node-agent/flags"
@@ -15,12 +22,6 @@ import (
 	"golang.org/x/sys/unix"
 	"golang.org/x/time/rate"
 	"k8s.io/klog/v2"
-	"net/http"
-	_ "net/http/pprof"
-	"os"
-	"path"
-	"runtime"
-	"strings"
 )
 
 var (
@@ -95,7 +96,7 @@ func whitelistNodeExternalNetworks() {
 
 func main() {
 	klog.LogToStderr(false)
-	klog.SetOutput(&RateLimitedLogOutput{limiter: rate.NewLimiter(10, 100)})
+	klog.SetOutput(&RateLimitedLogOutput{limiter: rate.NewLimiter(rate.Limit(*flags.LogPerSecond), *flags.LogBurst)})
 
 	klog.Infoln("agent version:", version)
 


### PR DESCRIPTION
This idea occurred to me during the discussion of https://github.com/coroot/coroot-node-agent/issues/55.

```
usage: coroot-node-agent [<flags>]

Flags:
....
      --log-per-second=10.0  The number of logs per second
      --log-burst=100        The maximum number of tokens that can be consumed
                             in a single call to allow
```