### PR TITLE
Outbound connection invalidation

### DIFF
--- a/ebpftracer/ebpf/tcp/state.c
+++ b/ebpftracer/ebpf/tcp/state.c
@@ -173,3 +173,29 @@ int sys_exit_connect(void *ctx) {
     return 0;
 }
 
+static inline __attribute__((__always_inline__))
+int trace_exit_accept(struct trace_event_raw_sys_exit__stub* ctx) {
+    if (ctx->ret < 0) {
+        return 0;
+    }
+    __u64 id = bpf_get_current_pid_tgid();
+    struct sk_info k = {};
+    k.pid = id >> 32;
+    k.fd = ctx->ret;
+    __u64 invalid_timestamp = 0;
+    bpf_map_update_elem(&connection_timestamps, &k, &invalid_timestamp, BPF_ANY);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_exit_accept")
+int sys_exit_accept(struct trace_event_raw_sys_exit__stub* ctx) {
+    return trace_exit_accept(ctx);
+}
+
+SEC("tracepoint/syscalls/sys_exit_accept4")
+int sys_exit_accept4(struct trace_event_raw_sys_exit__stub* ctx) {
+    return trace_exit_accept(ctx);
+}
+
+
+


### PR DESCRIPTION
Since the agent doesn't track inbound TCP connections, there could be situations where a socket file descriptor (FD) from a previous outbound connection is reused for a new inbound connection. It could result in inaccurate metrics and traces.