### PR TITLE
Sorted the order of file paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func uname() (string, string, error) {
 }
 
 func machineID() string {
-	for _, p := range []string{"sys/devices/virtual/dmi/id/product_uuid", "etc/machine-id", "var/lib/dbus/machine-id"} {
+	for _, p := range []string{"etc/machine-id", "sys/devices/virtual/dmi/id/product_uuid", "var/lib/dbus/machine-id"} {
 		payload, err := os.ReadFile(path.Join("/proc/1/root", p))
 		if err != nil {
 			klog.Warningln("failed to read machine-id:", err)

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func uname() (string, string, error) {
 }
 
 func machineID() string {
-	for _, p := range []string{"etc/machine-id", "sys/devices/virtual/dmi/id/product_uuid", "var/lib/dbus/machine-id"} {
+	for _, p := range []string{"etc/machine-id", "var/lib/dbus/machine-id", "sys/devices/virtual/dmi/id/product_uuid"} {
 		payload, err := os.ReadFile(path.Join("/proc/1/root", p))
 		if err != nil {
 			klog.Warningln("failed to read machine-id:", err)


### PR DESCRIPTION
Good afternoon, Coroot team!

I kindly ask for your attention to my pull request. The changes made are due to some cloud providers creating virtual machines with the same product_uuid. This leads to a situation in the Coroot web interface where a single node represents multiple virtual machines. The change in the order of paths will resolve this issue and ensure correct representation of virtual machines in the interface.

Thank you in advance for considering this.