### PR TITLE
support mariadb (fully compatible with mysql)

### DIFF
--- a/containers/app.go
+++ b/containers/app.go
@@ -32,6 +32,8 @@ func guessApplicationType(cmdline []byte) string {
 		return "mongos"
 	case bytes.HasSuffix(cmd, []byte("mysqld")):
 		return "mysql"
+	case bytes.HasSuffix(cmd, []byte("mariadbd")):
+		return "mysql"
 	case bytes.Contains(cmdline, []byte("org.apache.zookeeper.server.quorum.QuorumPeerMain")):
 		return "zookeeper"
 	case bytes.HasSuffix(cmd, []byte("redis-server")):


### PR DESCRIPTION
having read that coroot now supports mysql i was happy to check it out - to see if i can get some better analysis of some of my databases. i could not get it to work though, the screenshot in the 1.3.0 release notes shows a mariadb database, but i could not get mariadb databases to show up - only mysql ones (see here: [1.3.0 release notes](https://github.com/coroot/coroot/releases/tag/v1.3.0) )
having a look at the code, it seemed like if the running process was identifies to be mysqld - a metric would be set which would then indicate the application type. so, adding the mariadbd to the process list to set the mysql label worked perfectly.
since they are protocol (and a lot of code) compatible, all features work fine, including the mysql tab, as well as profiling, io, etc...