### PR TITLE
Add flag for disabing golang l7 tracing

### DIFF
--- a/containers/registry.go
+++ b/containers/registry.go
@@ -110,7 +110,7 @@ func NewRegistry(reg prometheus.Registerer, processInfoCh chan<- ProcessInfo) (*
 
 		processInfoCh: processInfoCh,
 
-		tracer: ebpftracer.NewTracer(hostNetNs, selfNetNs, *flags.DisableL7Tracing),
+		tracer: ebpftracer.NewTracer(hostNetNs, selfNetNs, *flags.DisableL7Tracing, *flags.DisableGoTlsUprobes),
 
 		trafficStatsUpdateCh: make(chan *TrafficStatsUpdate),
 	}

--- a/ebpftracer/tls.go
+++ b/ebpftracer/tls.go
@@ -118,7 +118,7 @@ func (t *Tracer) AttachOpenSslUprobes(pid uint32) []link.Link {
 
 func (t *Tracer) AttachGoTlsUprobes(pid uint32) ([]link.Link, bool) {
 	isGolangApp := false
-	if t.disableL7Tracing {
+	if t.disableL7Tracing || t.disableGoTlsUprobes {
 		return nil, isGolangApp
 	}
 

--- a/ebpftracer/tracer.go
+++ b/ebpftracer/tracer.go
@@ -81,9 +81,10 @@ const (
 )
 
 type Tracer struct {
-	disableL7Tracing bool
-	hostNetNs        netns.NsHandle
-	selfNetNs        netns.NsHandle
+	disableL7Tracing    bool
+	disableGoTlsUprobes bool
+	hostNetNs           netns.NsHandle
+	selfNetNs           netns.NsHandle
 
 	collection *ebpf.Collection
 	readers    map[string]*perf.Reader
@@ -91,14 +92,15 @@ type Tracer struct {
 	uprobes    map[string]*ebpf.Program
 }
 
-func NewTracer(hostNetNs, selfNetNs netns.NsHandle, disableL7Tracing bool) *Tracer {
+func NewTracer(hostNetNs, selfNetNs netns.NsHandle, disableL7Tracing, disableGoTlsUprobes bool) *Tracer {
 	if disableL7Tracing {
 		klog.Infoln("L7 tracing is disabled")
 	}
 	return &Tracer{
-		disableL7Tracing: disableL7Tracing,
-		hostNetNs:        hostNetNs,
-		selfNetNs:        selfNetNs,
+		disableL7Tracing:    disableL7Tracing,
+		disableGoTlsUprobes: disableGoTlsUprobes,
+		hostNetNs:           hostNetNs,
+		selfNetNs:           selfNetNs,
 
 		readers: map[string]*perf.Reader{},
 		uprobes: map[string]*ebpf.Program{},

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -9,11 +9,12 @@ import (
 )
 
 var (
-	ListenAddress     = kingpin.Flag("listen", "Listen address - ip:port or :port").Default("0.0.0.0:80").Envar("LISTEN").String()
-	CgroupRoot        = kingpin.Flag("cgroupfs-root", "The mount point of the host cgroupfs root").Default("/sys/fs/cgroup").Envar("CGROUPFS_ROOT").String()
-	DisableLogParsing = kingpin.Flag("disable-log-parsing", "Disable container log parsing").Default("false").Envar("DISABLE_LOG_PARSING").Bool()
-	DisablePinger     = kingpin.Flag("disable-pinger", "Don't ping upstreams").Default("false").Envar("DISABLE_PINGER").Bool()
-	DisableL7Tracing  = kingpin.Flag("disable-l7-tracing", "Disable L7 tracing").Default("false").Envar("DISABLE_L7_TRACING").Bool()
+	ListenAddress       = kingpin.Flag("listen", "Listen address - ip:port or :port").Default("0.0.0.0:80").Envar("LISTEN").String()
+	CgroupRoot          = kingpin.Flag("cgroupfs-root", "The mount point of the host cgroupfs root").Default("/sys/fs/cgroup").Envar("CGROUPFS_ROOT").String()
+	DisableLogParsing   = kingpin.Flag("disable-log-parsing", "Disable container log parsing").Default("false").Envar("DISABLE_LOG_PARSING").Bool()
+	DisablePinger       = kingpin.Flag("disable-pinger", "Don't ping upstreams").Default("false").Envar("DISABLE_PINGER").Bool()
+	DisableL7Tracing    = kingpin.Flag("disable-l7-tracing", "Disable L7 tracing").Default("false").Envar("DISABLE_L7_TRACING").Bool()
+	DisableGoTlsUprobes = kingpin.Flag("disable-go-tls-uprobes", "Disable golang lts uprobes").Default("false").Envar("DISABLE_GO_TLS_UPROBES").Bool()
 
 	ExternalNetworksWhitelist = kingpin.
 					Flag("track-public-network", "Allow track connections to the specified IP networks, all private networks are allowed by default (e.g., Y.Y.Y.Y/mask)").


### PR DESCRIPTION
This solves issue https://github.com/coroot/coroot-node-agent/issues/175, allowing to disable only golang l7 tracing
Left part with default envs, middle part with variable `DISABLE_L7_TRACING` == true, right part with `DISABLE_GO_TLS_UPROBES` == true
![image](https://github.com/user-attachments/assets/d0fb77ef-2f8c-4b4a-abf7-209e8e6d4f1e)