### PR TITLE
Add more JVM information to jvm_info 

### DIFF
--- a/containers/container.go
+++ b/containers/container.go
@@ -360,7 +360,13 @@ func (c *Container) Collect(ch chan<- prometheus.Metric) {
 		}
 		switch {
 		case proc.IsJvm(cmdline):
-			jvm, jMetrics := jvmMetrics(pid)
+			// Parse JVM parameters from command line and environment variables
+			// Convert null-separated command line to space-separated string
+			cmdlineStr := strings.ReplaceAll(string(cmdline), "\x00", " ")
+			cmdlineStr = strings.TrimSpace(cmdlineStr)
+
+			jvmParams := ParseJVMParams(cmdlineStr, pid)
+			jvm, jMetrics := jvmMetrics(pid, jvmParams)
 			if len(jMetrics) > 0 && !seenJvms[jvm] {
 				seenJvms[jvm] = true
 				for _, m := range jMetrics {

--- a/containers/jvm.go
+++ b/containers/jvm.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func jvmMetrics(pid uint32) (string, []prometheus.Metric) {
+func jvmMetrics(pid uint32, jvmParams JVMParams) (string, []prometheus.Metric) {
 	nsPid, err := proc.GetNsPid(pid)
 	if err != nil {
 		if !common.IsNotExist(err) {
@@ -37,7 +37,12 @@ func jvmMetrics(pid uint32) (string, []prometheus.Metric) {
 	jvm := pd.getString("sun.rt.javaCommand")
 	var res []prometheus.Metric
 
-	res = append(res, gauge(metrics.JvmInfo, 1, jvm, pd.getString("java.property.java.version")))
+	res = append(res, gauge(metrics.JvmInfo, 1, jvm, pd.getString("java.property.java.version"),
+		jvmParams.JavaMaxHeapSize,
+		jvmParams.JavaInitialHeapSize,
+		jvmParams.JavaMaxHeapAsPercentage,
+		jvmParams.JavaInitialHeapAsPercentage,
+		jvmParams.GCType))
 
 	func() {
 		size := float64(0)

--- a/containers/jvm_param_parser.go
+++ b/containers/jvm_param_parser.go
@@ -1,0 +1,143 @@
+package containers
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/coroot/coroot-node-agent/jvm"
+	"k8s.io/klog/v2"
+)
+
+type JVMParams struct {
+	JavaMaxHeapSize             string // heap size as string (e.g., "1073741824")
+	JavaInitialHeapSize         string // heap size as string (e.g., "268435456")
+	JavaMaxHeapAsPercentage     string // percentage value as string (e.g., "75.0")
+	JavaInitialHeapAsPercentage string // percentage value as string (e.g., "25.0")
+	GCType                      string // garbage collector type (e.g., G1GC, SerialGC, ParallelGC, etc.)
+}
+
+func ParseJVMParams(cmdline string, pid uint32) JVMParams {
+	// Get VM flags directly from the running JVM
+	vmFlags, err := jvm.GetVMFlags(pid)
+	if err != nil {
+		klog.Warningf("Failed to get VM flags for PID %d (only HotSpot JVMs supported): %v", pid, err)
+		return JVMParams{GCType: "Unknown"}
+	}
+
+	if strings.TrimSpace(vmFlags) == "" {
+		klog.Warningf("Empty VM flags output for PID %d", pid)
+		return JVMParams{GCType: "Unknown"}
+	}
+
+	return parseVMFlagsOutput(vmFlags)
+}
+
+// parseGCType extracts the garbage collector type from VM flags
+func parseGCType(flags []string) string {
+	// GC flags in order of precedence (newer/more specific GCs first)
+	gcFlags := []struct {
+		flag   string
+		gcType string
+	}{
+		{"+UseZGC", "ZGC"},
+		{"+UseShenandoahGC", "ShenandoahGC"},
+		{"+UseG1GC", "G1GC"},
+		{"+UseParallelGC", "ParallelGC"},
+		{"+UseParallelOldGC", "ParallelOldGC"},
+		{"+UseConcMarkSweepGC", "ConcMarkSweepGC"},
+		{"+UseSerialGC", "SerialGC"},
+	}
+
+	// Look for enabled GC flags (last one wins if multiple are specified)
+	var detectedGC string
+	for _, flag := range flags {
+		for _, gc := range gcFlags {
+			if strings.Contains(flag, gc.flag) {
+				detectedGC = gc.gcType
+			}
+		}
+	}
+
+	// If no explicit GC flag found, try to infer from other flags
+	if detectedGC == "" {
+		for _, flag := range flags {
+			if strings.Contains(flag, "G1") {
+				return "G1GC"
+			}
+			if strings.Contains(flag, "Parallel") && !strings.Contains(flag, "-UseParallelGC") {
+				return "ParallelGC"
+			}
+			if strings.Contains(flag, "ConcMarkSweep") || strings.Contains(flag, "CMS") {
+				return "ConcMarkSweepGC"
+			}
+			if strings.Contains(flag, "Serial") && !strings.Contains(flag, "-UseSerialGC") {
+				return "SerialGC"
+			}
+		}
+	}
+
+	// Default to unknown if no GC type can be determined
+	if detectedGC == "" {
+		return "Unknown"
+	}
+
+	return detectedGC
+}
+
+// parseVMFlagsOutput parses the output from jcmd VM.flags command
+func parseVMFlagsOutput(vmFlagsOutput string) JVMParams {
+	params := JVMParams{}
+
+	// Split the output by spaces to get individual flags
+	flags := strings.Fields(vmFlagsOutput)
+
+	for _, flag := range flags {
+		flag = strings.TrimSpace(flag)
+		if flag == "" {
+			continue
+		}
+
+		// Parse VM flags in format: -XX:MaxHeapSize=2147483648
+		if strings.HasPrefix(flag, "-XX:") {
+			// Parse specific flags we care about
+			if strings.Contains(flag, "MaxHeapSize=") {
+				if value := extractFlagValue(flag, "MaxHeapSize"); value != "" {
+					params.JavaMaxHeapSize = value
+				}
+			} else if strings.Contains(flag, "MinHeapSize=") {
+				if value := extractFlagValue(flag, "MinHeapSize"); value != "" {
+					params.JavaInitialHeapSize = value
+				}
+			} else if strings.Contains(flag, "InitialHeapSize=") {
+				if value := extractFlagValue(flag, "InitialHeapSize"); value != "" {
+					params.JavaInitialHeapSize = value
+				}
+			} else if strings.Contains(flag, "MaxRAMPercentage=") {
+				if value := extractFlagValue(flag, "MaxRAMPercentage"); value != "" {
+					params.JavaMaxHeapAsPercentage = value
+				}
+			} else if strings.Contains(flag, "InitialRAMPercentage=") {
+				if value := extractFlagValue(flag, "InitialRAMPercentage"); value != "" {
+					params.JavaInitialHeapAsPercentage = value
+				}
+			}
+		}
+	}
+
+	// Parse GC type from all flags
+	params.GCType = parseGCType(flags)
+
+	return params
+}
+
+// extractFlagValue extracts the value from a VM flag like "-XX:MaxHeapSize=2147483648"
+func extractFlagValue(line, flagName string) string {
+	pattern := fmt.Sprintf(`-XX:%s=([^\s]+)`, flagName)
+	re := regexp.MustCompile(pattern)
+	matches := re.FindStringSubmatch(line)
+	if len(matches) > 1 {
+		return matches[1]
+	}
+	return ""
+}

--- a/containers/metrics.go
+++ b/containers/metrics.go
@@ -93,7 +93,7 @@ var metrics = struct {
 
 	ApplicationType: metric("container_application_type", "Type of the application running in the container (e.g. memcached, postgres, mysql)", "application_type"),
 
-	JvmInfo:              metric("container_jvm_info", "Meta information about the JVM", "jvm", "java_version"),
+	JvmInfo:              metric("container_jvm_info", "Meta information about the JVM", "jvm", "java_version", "max_heap_size", "initial_heap_size", "max_heap_percentage", "initial_heap_percentage", "gc_type"),
 	JvmHeapSize:          metric("container_jvm_heap_size_bytes", "Total heap size in bytes", "jvm"),
 	JvmHeapUsed:          metric("container_jvm_heap_used_bytes", "Used heap size in bytes", "jvm"),
 	JvmGCTime:            metric("container_jvm_gc_time_seconds", "Time spent in the given JVM garbage collector in seconds", "jvm", "gc"),

--- a/jvm/perfmap.go
+++ b/jvm/perfmap.go
@@ -17,6 +17,19 @@ func DumpPerfmap(pid uint32) error {
 	return nil
 }
 
+func GetVMFlags(pid uint32) (string, error) {
+	j, err := Dial(pid)
+	if err != nil {
+		return "", fmt.Errorf("failed to attach to JVM %d: %w", pid, err)
+	}
+	defer j.Close()
+	vmFlags, err := j.GetVMFlags()
+	if err != nil {
+		return "", fmt.Errorf("failed to get VM flags of JVM %d: %w", pid, err)
+	}
+	return vmFlags, nil
+}
+
 func IsPerfmapDumpSupported(cmdline []byte) bool {
 	if !bytes.Contains(cmdline, []byte("-XX:+PreserveFramePointer")) {
 		return false


### PR DESCRIPTION
Added Heap and GC information to the jvm_info metric by using jattach (jcmd "VM.flags"):
**Labels added:**
- max_heap_size
- initial_heap_size
- max_heap_percentage
- initial_heap_percentage
- gc_type