### PR TITLE
Update netDeviceFilterRe to allow enP4p65s0 and enP2p33s0

### DIFF
--- a/node/net.go
+++ b/node/net.go
@@ -9,7 +9,7 @@ import (
 	"inet.af/netaddr"
 )
 
-var netDeviceFilterRe = regexp.MustCompile(`^(enp\d+s\d+(f\d+)?|eth\d+|eno\d+|ens\d+|em\d+|bond\d+|p\d+p\d+|enx[0-9a-f]{12})`)
+var netDeviceFilterRe = regexp.MustCompile(`^(en(P\d+)?p\d+s\d+(f\d+)?|eth\d+|eno\d+|ens\d+|em\d+|bond\d+|p\d+p\d+|enx[0-9a-f]{12})`)
 
 func netDeviceFilter(name string) bool {
 	return netDeviceFilterRe.MatchString(name)

--- a/node/net_test.go
+++ b/node/net_test.go
@@ -17,6 +17,8 @@ func TestNetDeviceFilter(t *testing.T) {
 		"eno2":            true,
 		"em1":             true,
 		"enx78e7d1ea46da": true,
+		"enP4p65s0":       true,
+		"enP2p33s0":       true,
 
 		"dummy0":          false,
 		"docker0":         false,


### PR DESCRIPTION
Update filter to allow more network device names.
Resolves https://github.com/coroot/coroot-node-agent/issues/231