### PR TITLE
docker: use debian:bullseye instead of golang image to build with older glibc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
-FROM golang:1.24.7-trixie AS builder
-RUN apt update && apt install -y libsystemd-dev
+FROM debian:bullseye AS builder
+# Using Debian instead of the official Golang image because it’s based on newer OS versions
+# with newer glibc, which causes compatibility issues.
+
+RUN apt-get update && apt-get install -y \
+    curl git build-essential pkg-config libsystemd-dev
+
+ARG GO_VERSION=1.24.9
+RUN curl -fsSL https://go.dev/dl/go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz -o go.tar.gz && \
+    tar -C /usr/local -xzf go.tar.gz && rm go.tar.gz
+ENV PATH="/usr/local/go/bin:${PATH}"
+
 WORKDIR /tmp/src
 COPY go.mod .
 COPY go.sum .


### PR DESCRIPTION
Fixes #253 