### PR TITLE
Feat: Add custom CA file support for TLS cert verification

### DIFF
--- a/common/api.go
+++ b/common/api.go
@@ -1,7 +1,12 @@
 package common
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"os"
+
 	"github.com/coroot/coroot-node-agent/flags"
+	"k8s.io/klog/v2"
 )
 
 func AuthHeaders() map[string]string {
@@ -10,4 +15,25 @@ func AuthHeaders() map[string]string {
 		res["X-Api-Key"] = apiKey
 	}
 	return res
+}
+
+func TlsConfig() *tls.Config {
+	cfg := &tls.Config{InsecureSkipVerify: *flags.InsecureSkipVerify}
+	if *flags.CAFile != "" {
+		ca, err := os.ReadFile(*flags.CAFile)
+		if err != nil {
+			klog.Errorln(err)
+			return cfg
+		}
+		pool, err := x509.SystemCertPool()
+		if err != nil {
+			klog.Warningln("failed to load system cert pool, starting with empty pool:", err)
+			pool = x509.NewCertPool()
+		}
+		if !pool.AppendCertsFromPEM(ca) {
+			klog.Errorf("failed to parse CA from %s", *flags.CAFile)
+		}
+		cfg.RootCAs = pool
+	}
+	return cfg
 }

--- a/common/api.go
+++ b/common/api.go
@@ -22,7 +22,7 @@ func TlsConfig() *tls.Config {
 	if *flags.CAFile != "" {
 		ca, err := os.ReadFile(*flags.CAFile)
 		if err != nil {
-			klog.Errorln(err)
+			klog.Fatalln(err)
 			return cfg
 		}
 		pool, err := x509.SystemCertPool()
@@ -31,7 +31,7 @@ func TlsConfig() *tls.Config {
 			pool = x509.NewCertPool()
 		}
 		if !pool.AppendCertsFromPEM(ca) {
-			klog.Errorf("failed to parse CA from %s", *flags.CAFile)
+			klog.Fatalf("failed to parse CA from %s", *flags.CAFile)
 		}
 		cfg.RootCAs = pool
 	}

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -51,6 +51,7 @@ var (
 	LogsEndpoint       = kingpin.Flag("logs-endpoint", "The URL of the endpoint to send logs to").Envar("LOGS_ENDPOINT").URL()
 	ProfilesEndpoint   = kingpin.Flag("profiles-endpoint", "The URL of the endpoint to send profiles to").Envar("PROFILES_ENDPOINT").URL()
 	InsecureSkipVerify = kingpin.Flag("insecure-skip-verify", "whether to skip verifying the certificate or not").Envar("INSECURE_SKIP_VERIFY").Default("false").Bool()
+	CAFile             = kingpin.Flag("ca-file", "Path to the custom CA certificate file").Envar("CA_FILE").String()
 
 	ScrapeInterval = kingpin.Flag("scrape-interval", "How often to gather metrics from the agent").Default("15s").Envar("SCRAPE_INTERVAL").Duration()
 	WalDir         = kingpin.Flag("wal-dir", "Path to where the agent stores data (e.g. the metrics Write-Ahead Log)").Default("/tmp/coroot-node-agent").Envar("WAL_DIR").String()

--- a/logs/otel.go
+++ b/logs/otel.go
@@ -2,7 +2,6 @@ package logs
 
 import (
 	"context"
-	"crypto/tls"
 	"time"
 
 	otel "github.com/agoda-com/opentelemetry-logs-go"
@@ -37,7 +36,7 @@ func Init(machineId, hostname, version string) {
 		otlplogshttp.WithEndpoint(endpointUrl.Host),
 		otlplogshttp.WithURLPath(path),
 		otlplogshttp.WithHeaders(common.AuthHeaders()),
-		otlplogshttp.WithTLSClientConfig(&tls.Config{InsecureSkipVerify: *flags.InsecureSkipVerify}),
+		otlplogshttp.WithTLSClientConfig(common.TlsConfig()),
 	}
 	if endpointUrl.Scheme != "https" {
 		opts = append(opts, otlplogshttp.WithInsecure())

--- a/profiling/profiling.go
+++ b/profiling/profiling.go
@@ -2,7 +2,6 @@ package profiling
 
 import (
 	"bytes"
-	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -39,7 +38,7 @@ var (
 	httpClient  = http.Client{
 		Timeout: UploadTimeout,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: *flags.InsecureSkipVerify},
+			TLSClientConfig: common.TlsConfig(),
 		},
 	}
 	endpointUrl          *url.URL

--- a/prom/remote_writer.go
+++ b/prom/remote_writer.go
@@ -2,7 +2,6 @@ package prom
 
 import (
 	"crypto/md5"
-	"crypto/tls"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -67,7 +66,7 @@ func StartAgent(reg *prometheus.Registry, machineId, systemUuid string) error {
 		httpClient: http.Client{
 			Timeout: RemoteWriteTimeout,
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: *flags.InsecureSkipVerify},
+				TLSClientConfig: common.TlsConfig(),
 			},
 		},
 		spoolDir:     path.Join(*flags.WalDir, "spool"),

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -2,7 +2,6 @@ package tracing
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"math/rand"
 	"time"
@@ -57,7 +56,7 @@ func Init(machineId, hostname, version string) {
 		otlptracehttp.WithEndpoint(endpointUrl.Host),
 		otlptracehttp.WithURLPath(path),
 		otlptracehttp.WithHeaders(common.AuthHeaders()),
-		otlptracehttp.WithTLSClientConfig(&tls.Config{InsecureSkipVerify: *flags.InsecureSkipVerify}),
+		otlptracehttp.WithTLSClientConfig(common.TlsConfig()),
 	}
 	if endpointUrl.Scheme != "https" {
 		opts = append(opts, otlptracehttp.WithInsecure())


### PR DESCRIPTION
As we have enabled TLS support in coroot application, at present there is no way to validate the server certificate when node-agent tries to connect to collector endpoints(profiles, metrics etc) of coroot.

One option is to use flag INSECURE_SKIP_VERIFY , but this is a not so secure workaround

I have added a new env var CA_FILE, on specifiying the crt path, will be used to validate cert