### PR TITLE
Add configurable startup delay for JVM async-profiler

### DIFF
--- a/flags/flags.go
+++ b/flags/flags.go
@@ -17,7 +17,7 @@ var (
 	DisableGPUMonitoring    = kingpin.Flag("disable-gpu-monitoring", "Disable GPU monitoring (NVML)").Default("false").Envar("DISABLE_GPU_MONITORING").Bool()
 	EnableJavaTls           = kingpin.Flag("enable-java-tls", "Enable Java TLS instrumentation via dynamic agent loading").Default("false").Envar("ENABLE_JAVA_TLS").Bool()
 	EnableJavaAsyncProfiler = kingpin.Flag("enable-java-async-profiler", "Enable Java profiling via async-profiler (CPU, memory allocations, lock contention)").Default("false").Envar("ENABLE_JAVA_ASYNC_PROFILER").Bool()
-	JavaAsyncProfilerDelay  = kingpin.Flag("java-async-profiler-delay", "Delay in seconds before starting async-profiler after JVM process is detected").Default("0").Envar("JAVA_ASYNC_PROFILER_DELAY").Int()
+	JavaAsyncProfilerDelay  = kingpin.Flag("java-async-profiler-delay", "Delay in seconds before starting async-profiler after JVM process is detected").Default("30").Envar("JAVA_ASYNC_PROFILER_DELAY").Int()
 	GoHeapProfilerMode      = kingpin.Flag("go-heap-profiler", "Go heap profiling mode: disabled, enabled (collect from apps with profiling on), force (enable profiling in all Go apps)").Default("enabled").Envar("GO_HEAP_PROFILER").String()
 
 	ContainerAllowlist = kingpin.Flag("container-allowlist", "List of allowed containers (regex patterns)").Envar("CONTAINER_ALLOWLIST").Strings()

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -17,7 +17,7 @@ var (
 	DisableGPUMonitoring    = kingpin.Flag("disable-gpu-monitoring", "Disable GPU monitoring (NVML)").Default("false").Envar("DISABLE_GPU_MONITORING").Bool()
 	EnableJavaTls           = kingpin.Flag("enable-java-tls", "Enable Java TLS instrumentation via dynamic agent loading").Default("false").Envar("ENABLE_JAVA_TLS").Bool()
 	EnableJavaAsyncProfiler = kingpin.Flag("enable-java-async-profiler", "Enable Java profiling via async-profiler (CPU, memory allocations, lock contention)").Default("false").Envar("ENABLE_JAVA_ASYNC_PROFILER").Bool()
-	JavaAsyncProfilerDelay  = kingpin.Flag("java-async-profiler-delay", "Delay in seconds before starting async-profiler after JVM process is detected").Default("30").Envar("JAVA_ASYNC_PROFILER_DELAY").Int()
+	JavaAsyncProfilerDelay  = kingpin.Flag("java-async-profiler-delay", "Delay in seconds before starting async-profiler after JVM process is detected").Default("30s").Envar("JAVA_ASYNC_PROFILER_DELAY").Duration()
 	GoHeapProfilerMode      = kingpin.Flag("go-heap-profiler", "Go heap profiling mode: disabled, enabled (collect from apps with profiling on), force (enable profiling in all Go apps)").Default("enabled").Envar("GO_HEAP_PROFILER").String()
 
 	ContainerAllowlist = kingpin.Flag("container-allowlist", "List of allowed containers (regex patterns)").Envar("CONTAINER_ALLOWLIST").Strings()

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -17,6 +17,7 @@ var (
 	DisableGPUMonitoring    = kingpin.Flag("disable-gpu-monitoring", "Disable GPU monitoring (NVML)").Default("false").Envar("DISABLE_GPU_MONITORING").Bool()
 	EnableJavaTls           = kingpin.Flag("enable-java-tls", "Enable Java TLS instrumentation via dynamic agent loading").Default("false").Envar("ENABLE_JAVA_TLS").Bool()
 	EnableJavaAsyncProfiler = kingpin.Flag("enable-java-async-profiler", "Enable Java profiling via async-profiler (CPU, memory allocations, lock contention)").Default("false").Envar("ENABLE_JAVA_ASYNC_PROFILER").Bool()
+	JavaAsyncProfilerDelay  = kingpin.Flag("java-async-profiler-delay", "Delay in seconds before starting async-profiler after JVM process is detected").Default("0").Envar("JAVA_ASYNC_PROFILER_DELAY").Int()
 	GoHeapProfilerMode      = kingpin.Flag("go-heap-profiler", "Go heap profiling mode: disabled, enabled (collect from apps with profiling on), force (enable profiling in all Go apps)").Default("enabled").Envar("GO_HEAP_PROFILER").String()
 
 	ContainerAllowlist = kingpin.Flag("container-allowlist", "List of allowed containers (regex patterns)").Envar("CONTAINER_ALLOWLIST").Strings()

--- a/profiling/profiling.go
+++ b/profiling/profiling.go
@@ -211,8 +211,8 @@ func collectAsyncProfilerProfiles() {
 
 	for _, j := range jvms {
 		if !j.started {
-			if *flags.JavaAsyncProfilerDelay > 0 && !j.startedAt.IsZero() {
-				delay := time.Duration(*flags.JavaAsyncProfilerDelay) * time.Second
+			delay := *flags.JavaAsyncProfilerDelay
+			if delay > 0 && !j.startedAt.IsZero() {
 				if time.Since(j.startedAt) < delay {
 					klog.Infof("pid=%d: delaying async-profiler start (waiting for %v since start)", j.pid, delay-time.Since(j.startedAt))
 					continue

--- a/profiling/profiling.go
+++ b/profiling/profiling.go
@@ -193,7 +193,7 @@ func collectAsyncProfilerProfiles() {
 		serviceName string
 		containerID string
 		started     bool
-		detectedAt  time.Time
+		startedAt   time.Time
 	}
 	var jvms []jvmInfo
 	for pid, pi := range targetFinder.processes {
@@ -203,7 +203,7 @@ func collectAsyncProfilerProfiles() {
 				serviceName: pi.serviceName,
 				containerID: pi.containerId,
 				started:     pi.asyncProfilerStarted,
-				detectedAt:  pi.jvmDetectedAt,
+				startedAt:   time.Unix(0, pi.startedAt),
 			})
 		}
 	}
@@ -211,11 +211,10 @@ func collectAsyncProfilerProfiles() {
 
 	for _, j := range jvms {
 		if !j.started {
-			// Check if we need to wait before starting the profiler
-			if *flags.JavaAsyncProfilerDelay > 0 && !j.detectedAt.IsZero() {
+			if *flags.JavaAsyncProfilerDelay > 0 && !j.startedAt.IsZero() {
 				delay := time.Duration(*flags.JavaAsyncProfilerDelay) * time.Second
-				if time.Since(j.detectedAt) < delay {
-					klog.V(2).Infof("pid=%d: delaying async-profiler start (waiting for %v since detection)", j.pid, delay-time.Since(j.detectedAt))
+				if time.Since(j.startedAt) < delay {
+					klog.Infof("pid=%d: delaying async-profiler start (waiting for %v since start)", j.pid, delay-time.Since(j.startedAt))
 					continue
 				}
 			}
@@ -237,7 +236,7 @@ func collectAsyncProfilerProfiles() {
 				}
 				targetFinder.lock.Unlock()
 			} else {
-				klog.Infof("pid=%d: async-profiler started after %v delay", j.pid, time.Since(j.detectedAt).Truncate(time.Second))
+				klog.Infof("pid=%d: async-profiler started after %v delay", j.pid, time.Since(j.startedAt).Truncate(time.Second))
 				targetFinder.lock.Lock()
 				if pi := targetFinder.processes[j.pid]; pi != nil {
 					pi.asyncProfilerStarted = true
@@ -440,7 +439,6 @@ func (tf *TargetFinder) FindTarget(pid uint32) *sd.Target {
 		cmdline := proc.GetCmdline(pid)
 		if proc.IsJvm(cmdline) {
 			pi.isJvm = jvm.IsHotSpotJVM(pid)
-			pi.jvmDetectedAt = time.Now()
 			if !pi.flags.EbpfProfilingDisabled {
 				pi.jvmPerfmapDumpSupported = jvm.IsPerfmapDumpSupported(cmdline)
 			}
@@ -494,7 +492,6 @@ type processInfo struct {
 	flags       proc.Flags
 
 	isJvm                   bool
-	jvmDetectedAt           time.Time
 	jvmPerfmapDumpSupported bool
 	lastPerfmapDump         int64
 	asyncProfilerStarted    bool

--- a/profiling/profiling.go
+++ b/profiling/profiling.go
@@ -193,6 +193,7 @@ func collectAsyncProfilerProfiles() {
 		serviceName string
 		containerID string
 		started     bool
+		detectedAt  time.Time
 	}
 	var jvms []jvmInfo
 	for pid, pi := range targetFinder.processes {
@@ -202,6 +203,7 @@ func collectAsyncProfilerProfiles() {
 				serviceName: pi.serviceName,
 				containerID: pi.containerId,
 				started:     pi.asyncProfilerStarted,
+				detectedAt:  pi.jvmDetectedAt,
 			})
 		}
 	}
@@ -209,6 +211,15 @@ func collectAsyncProfilerProfiles() {
 
 	for _, j := range jvms {
 		if !j.started {
+			// Check if we need to wait before starting the profiler
+			if *flags.JavaAsyncProfilerDelay > 0 && !j.detectedAt.IsZero() {
+				delay := time.Duration(*flags.JavaAsyncProfilerDelay) * time.Second
+				if time.Since(j.detectedAt) < delay {
+					klog.V(2).Infof("pid=%d: delaying async-profiler start (waiting for %v since detection)", j.pid, delay-time.Since(j.detectedAt))
+					continue
+				}
+			}
+
 			if jvm.IsAsyncProfilerAlreadyLoaded(j.pid) {
 				klog.Infof("pid=%d: async-profiler already loaded by another tool, skipping", j.pid)
 				targetFinder.lock.Lock()
@@ -226,6 +237,7 @@ func collectAsyncProfilerProfiles() {
 				}
 				targetFinder.lock.Unlock()
 			} else {
+				klog.Infof("pid=%d: async-profiler started after %v delay", j.pid, time.Since(j.detectedAt).Truncate(time.Second))
 				targetFinder.lock.Lock()
 				if pi := targetFinder.processes[j.pid]; pi != nil {
 					pi.asyncProfilerStarted = true
@@ -428,6 +440,7 @@ func (tf *TargetFinder) FindTarget(pid uint32) *sd.Target {
 		cmdline := proc.GetCmdline(pid)
 		if proc.IsJvm(cmdline) {
 			pi.isJvm = jvm.IsHotSpotJVM(pid)
+			pi.jvmDetectedAt = time.Now()
 			if !pi.flags.EbpfProfilingDisabled {
 				pi.jvmPerfmapDumpSupported = jvm.IsPerfmapDumpSupported(cmdline)
 			}
@@ -481,6 +494,7 @@ type processInfo struct {
 	flags       proc.Flags
 
 	isJvm                   bool
+	jvmDetectedAt           time.Time
 	jvmPerfmapDumpSupported bool
 	lastPerfmapDump         int64
 	asyncProfilerStarted    bool

--- a/profiling/profiling.go
+++ b/profiling/profiling.go
@@ -214,7 +214,7 @@ func collectAsyncProfilerProfiles() {
 			delay := *flags.JavaAsyncProfilerDelay
 			if delay > 0 && !j.startedAt.IsZero() {
 				if time.Since(j.startedAt) < delay {
-					klog.Infof("pid=%d: delaying async-profiler start (waiting for %v since start)", j.pid, delay-time.Since(j.startedAt))
+					klog.Infof("pid=%d: delaying async-profiler start (waiting for %s since start)", j.pid, delay)
 					continue
 				}
 			}
@@ -229,14 +229,14 @@ func collectAsyncProfilerProfiles() {
 				continue
 			}
 			if err := jvm.DeployAndStartAsyncProfiler(j.pid); err != nil {
-				klog.Warningf("async-profiler start pid=%d: %v", j.pid, err)
+				klog.Warningf("async-profiler start pid=%d: %s", j.pid, err)
 				targetFinder.lock.Lock()
 				if pi := targetFinder.processes[j.pid]; pi != nil {
 					pi.asyncProfilerErr = true
 				}
 				targetFinder.lock.Unlock()
 			} else {
-				klog.Infof("pid=%d: async-profiler started after %v delay", j.pid, time.Since(j.startedAt).Truncate(time.Second))
+				klog.Infof("pid=%d: async-profiler started", j.pid)
 				targetFinder.lock.Lock()
 				if pi := targetFinder.processes[j.pid]; pi != nil {
 					pi.asyncProfilerStarted = true


### PR DESCRIPTION
JVM profiling can impact startup performance for slow-initializing Java applications. This adds a delay option to start the profiler only after the application is fully ready.