### PR TITLE
Add Nsight GPU metrics collection

### DIFF
--- a/flags/flags.go
+++ b/flags/flags.go
@@ -14,7 +14,7 @@ var (
 	DisableLogParsing       = kingpin.Flag("disable-log-parsing", "Disable container log parsing").Default("false").Envar("DISABLE_LOG_PARSING").Bool()
 	DisablePinger           = kingpin.Flag("disable-pinger", "Don't ping upstreams").Default("false").Envar("DISABLE_PINGER").Bool()
 	DisableL7Tracing        = kingpin.Flag("disable-l7-tracing", "Disable L7 tracing").Default("false").Envar("DISABLE_L7_TRACING").Bool()
-	DisableGPUMonitoring    = kingpin.Flag("disable-gpu-monitoring", "Disable GPU monitoring (NVML)").Default("false").Envar("DISABLE_GPU_MONITORING").Bool()
+	DisableGPUMonitoring    = kingpin.Flag("disable-gpu-monitoring", "Disable GPU monitoring (NVML/Nsight Systems)").Default("false").Envar("DISABLE_GPU_MONITORING").Bool()
 	EnableJavaTls           = kingpin.Flag("enable-java-tls", "Enable Java TLS instrumentation via dynamic agent loading").Default("false").Envar("ENABLE_JAVA_TLS").Bool()
 	EnableJavaAsyncProfiler = kingpin.Flag("enable-java-async-profiler", "Enable Java profiling via async-profiler (CPU, memory allocations, lock contention)").Default("false").Envar("ENABLE_JAVA_ASYNC_PROFILER").Bool()
 	JavaAsyncProfilerDelay  = kingpin.Flag("java-async-profiler-delay", "Delay in seconds before starting async-profiler after JVM process is detected").Default("30s").Envar("JAVA_ASYNC_PROFILER_DELAY").Duration()

--- a/gpu/gpu.go
+++ b/gpu/gpu.go
@@ -64,12 +64,23 @@ var (
 		"Peak GPU core utilization (percentage) over the collection interval",
 		[]string{"gpu_uuid"}, nil,
 	)
+	gpuComputeOccupancyAvg = prometheus.NewDesc(
+		"node_resources_gpu_compute_occupancy_percent_avg",
+		"Average GPU compute occupancy (percentage) over the collection interval",
+		[]string{"gpu_uuid"}, nil,
+	)
+	gpuComputeOccupancyPeak = prometheus.NewDesc(
+		"node_resources_gpu_compute_occupancy_percent_peak",
+		"Peak GPU compute occupancy (percentage) over the collection interval",
+		[]string{"gpu_uuid"}, nil,
+	)
 )
 
 type Collector struct {
 	ProcessUsageSampleCh chan ProcessUsageSample
 	iface                nvml.Interface
 	devices              []*Device
+	nsight               *nsightCollector
 	lock                 sync.Mutex
 }
 
@@ -130,7 +141,15 @@ func NewCollector() (*Collector, error) {
 		c.devices = append(c.devices, &dev)
 	}
 	if len(names) > 0 {
-		klog.Infof("found %d GPU: %s", len(names), strings.Join(names, ", "))
+		klog.Infof("found %d NVIDIA GPU: %s", len(names), strings.Join(names, ", "))
+		if nc, err := newNsightCollector(c.devices); err != nil {
+			klog.Infof("Nsight Systems GPU metrics disabled: %s", err)
+		} else {
+			c.nsight = nc
+			c.nsight.Start()
+		}
+	} else {
+		klog.Infoln("no NVIDIA GPUs detected")
 	}
 	go c.processUtilizationPoller()
 	return c, nil
@@ -169,6 +188,8 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- gpuMemoryUsagePeak
 	ch <- gpuUsageAvg
 	ch <- gpuUsagePeak
+	ch <- gpuComputeOccupancyAvg
+	ch <- gpuComputeOccupancyPeak
 	ch <- gpuTemperature
 	ch <- gpuPowerWatts
 }
@@ -176,6 +197,7 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
+	nsight := c.nsight.Snapshot()
 	for _, dev := range c.devices {
 		ch <- gauge(gpuInfo, 1, dev.UUID, dev.Name)
 
@@ -190,50 +212,66 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		if mw, ret := dev.device.GetPowerUsage(); ret == nvml.SUCCESS {
 			ch <- gauge(gpuPowerWatts, float64(mw)/1000., dev.UUID)
 		}
-		for _, st := range []nvml.SamplingType{nvml.GPU_UTILIZATION_SAMPLES, nvml.MEMORY_UTILIZATION_SAMPLES} {
-			lastTs := dev.lastSampleTime[st]
-			valtype, samples, ret := dev.device.GetSamples(st, lastTs)
-			if ret != nvml.SUCCESS {
-				continue
-			}
-			total := float64(0)
-			count := float64(0)
-			peak := float64(0)
-			for _, sample := range samples {
-				if sample.TimeStamp <= lastTs {
-					continue
-				}
-				value, err := valueToFloat(valtype, sample.SampleValue)
-				if err != nil {
-					continue
-				}
-				total += value
-				if value > peak {
-					peak = value
-				}
-				count++
-				lastTs = sample.TimeStamp
-			}
-			if count > 0 {
-				switch st {
-				case nvml.GPU_UTILIZATION_SAMPLES:
-					ch <- gauge(gpuUsageAvg, total/count, dev.UUID)
-					ch <- gauge(gpuUsagePeak, peak, dev.UUID)
-				case nvml.MEMORY_UTILIZATION_SAMPLES:
-					ch <- gauge(gpuMemoryUsageAvg, total/count, dev.UUID)
-					ch <- gauge(gpuMemoryUsagePeak, peak, dev.UUID)
-				}
-			}
-			dev.lastSampleTime[st] = lastTs
+		if m, ok := nsight[dev.UUID]; ok {
+			ch <- gauge(gpuUsageAvg, m.GPUUtilizationAvg, dev.UUID)
+			ch <- gauge(gpuUsagePeak, m.GPUUtilizationPeak, dev.UUID)
+			ch <- gauge(gpuMemoryUsageAvg, m.MemoryUtilizationAvg, dev.UUID)
+			ch <- gauge(gpuMemoryUsagePeak, m.MemoryUtilizationPeak, dev.UUID)
+			ch <- gauge(gpuComputeOccupancyAvg, m.ComputeOccupancyAvg, dev.UUID)
+			ch <- gauge(gpuComputeOccupancyPeak, m.ComputeOccupancyPeak, dev.UUID)
+		} else {
+			c.collectNVMLUtilization(ch, dev)
 		}
 	}
 }
 
 func (c *Collector) Close() {
+	if c.nsight != nil {
+		c.nsight.Close()
+	}
 	if c.iface == nil {
 		return
 	}
 	c.iface.Shutdown()
+}
+
+func (c *Collector) collectNVMLUtilization(ch chan<- prometheus.Metric, dev *Device) {
+	for _, st := range []nvml.SamplingType{nvml.GPU_UTILIZATION_SAMPLES, nvml.MEMORY_UTILIZATION_SAMPLES} {
+		lastTs := dev.lastSampleTime[st]
+		valtype, samples, ret := dev.device.GetSamples(st, lastTs)
+		if ret != nvml.SUCCESS {
+			continue
+		}
+		total := float64(0)
+		count := float64(0)
+		peak := float64(0)
+		for _, sample := range samples {
+			if sample.TimeStamp <= lastTs {
+				continue
+			}
+			value, err := valueToFloat(valtype, sample.SampleValue)
+			if err != nil {
+				continue
+			}
+			total += value
+			if value > peak {
+				peak = value
+			}
+			count++
+			lastTs = sample.TimeStamp
+		}
+		if count > 0 {
+			switch st {
+			case nvml.GPU_UTILIZATION_SAMPLES:
+				ch <- gauge(gpuUsageAvg, total/count, dev.UUID)
+				ch <- gauge(gpuUsagePeak, peak, dev.UUID)
+			case nvml.MEMORY_UTILIZATION_SAMPLES:
+				ch <- gauge(gpuMemoryUsageAvg, total/count, dev.UUID)
+				ch <- gauge(gpuMemoryUsagePeak, peak, dev.UUID)
+			}
+		}
+		dev.lastSampleTime[st] = lastTs
+	}
 }
 
 func findNvidiaMLLib() (string, error) {

--- a/gpu/nsight.go
+++ b/gpu/nsight.go
@@ -1,0 +1,434 @@
+package gpu
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/coroot/coroot-node-agent/flags"
+	"github.com/coroot/coroot-node-agent/proc"
+	"k8s.io/klog/v2"
+)
+
+const (
+	nsightCaptureDuration = 2 * time.Second
+	nsightMetricsFreqHz   = 100
+	nsightHostRoot        = "/proc/1/root"
+
+	nsightMetricGPUUtilization   = "GR Active [Throughput %]"
+	nsightMetricDRAMRead         = "DRAM Read Bandwidth [Throughput %]"
+	nsightMetricDRAMWrite        = "DRAM Write Bandwidth [Throughput %]"
+	nsightMetricComputeOccupancy = "Compute Warps in Flight [Throughput %]"
+)
+
+var nsightMetricsQuery = fmt.Sprintf(`
+WITH metric_samples AS (
+    SELECT
+        g.uuid AS gpu_uuid,
+        gm.timestamp AS timestamp,
+        max(CASE WHEN tim.metricName = %[1]q THEN gm.value END) AS gpu_utilization,
+        min(100, coalesce(max(CASE WHEN tim.metricName = %[2]q THEN gm.value END), 0) +
+                 coalesce(max(CASE WHEN tim.metricName = %[3]q THEN gm.value END), 0)) AS memory_utilization,
+        max(CASE WHEN tim.metricName = %[4]q THEN gm.value END) AS compute_occupancy
+    FROM GPU_METRICS gm
+    JOIN TARGET_INFO_GPU_METRICS tim ON gm.typeId = tim.typeId AND gm.metricId = tim.metricId
+    JOIN TARGET_INFO_GPU g ON tim.sourceId = g.vmId + ((g.id + 1) * 4294967296)
+    WHERE tim.metricName IN (%[1]q, %[2]q, %[3]q, %[4]q)
+    GROUP BY g.uuid, gm.timestamp
+)
+SELECT
+    gpu_uuid,
+    avg(gpu_utilization) AS gpu_utilization_avg,
+    max(gpu_utilization) AS gpu_utilization_peak,
+    avg(memory_utilization) AS memory_utilization_avg,
+    max(memory_utilization) AS memory_utilization_peak,
+    avg(compute_occupancy) AS compute_occupancy_avg,
+    max(compute_occupancy) AS compute_occupancy_peak
+FROM metric_samples
+GROUP BY gpu_uuid
+ORDER BY gpu_uuid;
+`, nsightMetricGPUUtilization, nsightMetricDRAMRead, nsightMetricDRAMWrite, nsightMetricComputeOccupancy)
+
+var nsightStatsReport = fmt.Sprintf(`#!/usr/bin/env python
+import nsysstats
+
+class CorootGpuMetrics(nsysstats.StatsReport):
+    display_name = 'Coroot GPU Metrics'
+    query = r"""%s"""
+    table_checks = {
+        'GPU_METRICS': '{DBFILE} does not contain GPU_METRICS table.',
+        'TARGET_INFO_GPU': '{DBFILE} does not contain TARGET_INFO_GPU table.',
+        'TARGET_INFO_GPU_METRICS': '{DBFILE} does not contain TARGET_INFO_GPU_METRICS table.',
+    }
+
+if __name__ == "__main__":
+    CorootGpuMetrics.Main()
+`, nsightMetricsQuery)
+
+type nsightCollector struct {
+	nsysPath string
+	interval time.Duration
+
+	lock    sync.RWMutex
+	metrics map[string]nsightMetrics
+
+	stopCh chan struct{}
+
+	lastErr   string
+	lastErrAt time.Time
+}
+
+type nsightMetrics struct {
+	GPUUtilizationAvg     float64
+	GPUUtilizationPeak    float64
+	MemoryUtilizationAvg  float64
+	MemoryUtilizationPeak float64
+	ComputeOccupancyAvg   float64
+	ComputeOccupancyPeak  float64
+	CollectedAt           time.Time
+}
+
+func newNsightCollector(devices []*Device) (*nsightCollector, error) {
+	if len(devices) == 0 {
+		return nil, errors.New("no NVIDIA GPUs detected")
+	}
+	var errs []string
+	var nsysPath string
+	for _, candidate := range findNsightSystemsCLIs() {
+		if err := checkNsightGPUMetrics(candidate); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %s", candidate, err))
+			continue
+		}
+		nsysPath = candidate
+		break
+	}
+	if nsysPath == "" {
+		if len(errs) == 0 {
+			return nil, errors.New("nsys not found")
+		}
+		return nil, fmt.Errorf("no usable nsys GPU metrics collector found: %s", strings.Join(errs, "; "))
+	}
+
+	interval := *flags.ScrapeInterval
+	if interval < nsightCaptureDuration+time.Second {
+		interval = nsightCaptureDuration + time.Second
+	}
+	klog.Infof("Nsight Systems GPU metrics enabled: %s", nsysPath)
+	return &nsightCollector{
+		nsysPath: nsysPath,
+		interval: interval,
+		metrics:  map[string]nsightMetrics{},
+		stopCh:   make(chan struct{}),
+	}, nil
+}
+
+func (c *nsightCollector) Start() {
+	go func() {
+		timer := time.NewTimer(0)
+		defer timer.Stop()
+		for {
+			select {
+			case <-c.stopCh:
+				return
+			case <-timer.C:
+				if metrics, err := c.collect(); err != nil {
+					c.logError(err)
+				} else {
+					c.lock.Lock()
+					c.metrics = metrics
+					c.lock.Unlock()
+				}
+				timer.Reset(c.interval)
+			}
+		}
+	}()
+}
+
+func (c *nsightCollector) Close() {
+	close(c.stopCh)
+}
+
+func (c *nsightCollector) Snapshot() map[string]nsightMetrics {
+	if c == nil {
+		return nil
+	}
+	maxAge := c.interval * 3
+	now := time.Now()
+	res := map[string]nsightMetrics{}
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for uuid, m := range c.metrics {
+		if now.Sub(m.CollectedAt) <= maxAge {
+			res[uuid] = m
+		}
+	}
+	return res
+}
+
+func (c *nsightCollector) collect() (map[string]nsightMetrics, error) {
+	tmpRoot := ""
+	if nsightRunsOnHost(c.nsysPath) {
+		tmpRoot = proc.HostPath("/tmp")
+	}
+	dir, err := os.MkdirTemp(tmpRoot, "coroot-nsys-")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+
+	reportBase := filepath.Join(dir, "gpu")
+	reportPath := reportBase + ".nsys-rep"
+	reportPluginPath := filepath.Join(dir, "coroot_gpu_metrics.py")
+	if err = os.WriteFile(reportPluginPath, []byte(nsightStatsReport), 0600); err != nil {
+		return nil, err
+	}
+	commandDir := nsightCommandPath(c.nsysPath, dir)
+	commandReportBase := filepath.Join(commandDir, "gpu")
+	commandReportPath := commandReportBase + ".nsys-rep"
+	commandSqlitePath := commandReportBase + ".sqlite"
+
+	ctx, cancel := context.WithTimeout(context.Background(), nsightCaptureDuration+30*time.Second)
+	defer cancel()
+	profileArgs := []string{
+		"profile",
+		fmt.Sprintf("--duration=%d", int(nsightCaptureDuration.Seconds())),
+		"--sample=none",
+		"--cpuctxsw=none",
+		"--trace=none",
+		"--gpu-metrics-devices=all",
+		fmt.Sprintf("--gpu-metrics-frequency=%d", nsightMetricsFreqHz),
+		"--stats=false",
+		"--show-output=false",
+		"--force-overwrite=true",
+		"--output=" + commandReportBase,
+		"/bin/sleep",
+		strconv.Itoa(int(nsightCaptureDuration.Seconds())),
+	}
+	if out, err := commandOutput(ctx, c.nsysPath, profileArgs...); err != nil {
+		return nil, fmt.Errorf("nsys profile failed: %w: %s", err, summarizeCommandOutput(out))
+	}
+	if _, err = os.Stat(reportPath); err != nil {
+		return nil, fmt.Errorf("nsys profile did not create %s: %w", reportPath, err)
+	}
+
+	statsArgs := []string{
+		"stats",
+		"--quiet",
+		"--force-export=true",
+		"--sqlite=" + commandSqlitePath,
+		"--report-dir",
+		commandDir,
+		"--report",
+		"coroot_gpu_metrics",
+		"--format",
+		"csv",
+		"--output",
+		"-",
+		commandReportPath,
+	}
+	out, err := commandOutput(ctx, c.nsysPath, statsArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("nsys stats failed: %w: %s", err, summarizeCommandOutput(out))
+	}
+	metrics, err := parseNsightMetricsCSV(out, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	if len(metrics) == 0 {
+		return nil, errors.New("nsys stats returned no GPU metrics")
+	}
+	return metrics, nil
+}
+
+func (c *nsightCollector) logError(err error) {
+	msg := err.Error()
+	now := time.Now()
+	if msg == c.lastErr && now.Sub(c.lastErrAt) < time.Minute {
+		return
+	}
+	c.lastErr = msg
+	c.lastErrAt = now
+	klog.Warningf("failed to collect Nsight Systems GPU metrics: %s", msg)
+}
+
+func findNsightSystemsCLI() (string, error) {
+	candidates := findNsightSystemsCLIs()
+	if len(candidates) == 0 {
+		return "", errors.New("nsys not found")
+	}
+	return candidates[0], nil
+}
+
+func findNsightSystemsCLIs() []string {
+	var candidates []string
+	seen := map[string]struct{}{}
+	add := func(path string) {
+		if path == "" {
+			return
+		}
+		if _, ok := seen[path]; ok {
+			return
+		}
+		if st, err := os.Stat(path); err == nil && st.Mode().Perm()&0111 != 0 {
+			seen[path] = struct{}{}
+			candidates = append(candidates, path)
+		}
+	}
+	if path, err := exec.LookPath("nsys"); err == nil {
+		add(path)
+	}
+	for _, p := range []string{
+		"/opt/nvidia/nsight-systems/*/target-linux-x64/nsys",
+		"/opt/nvidia/nsight-systems/*/target-linux-sbsa-armv8/nsys",
+		"/opt/nvidia/nsight-systems/*/target-linux-ppc64le/nsys",
+		"/opt/nvidia/nsight-systems-cli/*/target-linux-x64/nsys",
+		"/opt/nvidia/nsight-systems-cli/*/target-linux-sbsa-armv8/nsys",
+		"/opt/nvidia/nsight-systems-cli/*/target-linux-ppc64le/nsys",
+	} {
+		if !nsightPathMatchesArch(p) {
+			continue
+		}
+		matches, _ := filepath.Glob(proc.HostPath(p))
+		for _, match := range matches {
+			add(match)
+		}
+	}
+	return candidates
+}
+
+func nsightPathMatchesArch(path string) bool {
+	switch runtime.GOARCH {
+	case "amd64":
+		return strings.Contains(path, "x64")
+	case "arm64":
+		return strings.Contains(path, "sbsa-armv8")
+	case "ppc64le":
+		return strings.Contains(path, "ppc64le")
+	default:
+		return false
+	}
+}
+
+func checkNsightGPUMetrics(nsysPath string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := commandOutput(ctx, nsysPath, "profile", "--gpu-metrics-devices=help", "true")
+	if err != nil {
+		return fmt.Errorf("unable to query nsys GPU metrics support: %w: %s", err, summarizeCommandOutput(out))
+	}
+	if !bytes.Contains(out, []byte("\n\tall:")) && !bytes.Contains(out, []byte("\n    all:")) {
+		return fmt.Errorf("no supported GPU metrics devices reported by nsys: %s", summarizeCommandOutput(out))
+	}
+	return nil
+}
+
+func commandOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
+	if nsightRunsOnHost(name) {
+		name = nsightCommandPath(name, name)
+		args = append([]string{nsightHostRoot, name}, args...)
+		name = "chroot"
+	}
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = append(os.Environ(), "TERM=dumb", "NO_COLOR=1")
+	return cmd.CombinedOutput()
+}
+
+func nsightRunsOnHost(path string) bool {
+	return strings.HasPrefix(filepath.Clean(path), nsightHostRoot+string(os.PathSeparator))
+}
+
+func nsightCommandPath(nsysPath, path string) string {
+	if !nsightRunsOnHost(nsysPath) {
+		return path
+	}
+	clean := filepath.Clean(path)
+	if clean == nsightHostRoot {
+		return "/"
+	}
+	if strings.HasPrefix(clean, nsightHostRoot+string(os.PathSeparator)) {
+		return strings.TrimPrefix(clean, nsightHostRoot)
+	}
+	return path
+}
+
+func summarizeCommandOutput(out []byte) string {
+	const max = 512
+	s := strings.TrimSpace(strings.ReplaceAll(string(out), "\r", "\n"))
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}
+
+func parseNsightMetricsCSV(payload []byte, collectedAt time.Time) (map[string]nsightMetrics, error) {
+	reader := csv.NewReader(bytes.NewReader(payload))
+	reader.FieldsPerRecord = -1
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("invalid nsys stats CSV: %w", err)
+	}
+	res := map[string]nsightMetrics{}
+	for _, row := range records {
+		if len(row) == 0 || row[0] == "gpu_uuid" {
+			continue
+		}
+		if len(row) < 7 {
+			return nil, fmt.Errorf("invalid nsys stats row: %q", row)
+		}
+		uuid := normalizeGPUUUID(row[0])
+		if uuid == "" {
+			continue
+		}
+		m := nsightMetrics{CollectedAt: collectedAt}
+		if m.GPUUtilizationAvg, err = parseOptionalFloat(row[1]); err != nil {
+			return nil, err
+		}
+		if m.GPUUtilizationPeak, err = parseOptionalFloat(row[2]); err != nil {
+			return nil, err
+		}
+		if m.MemoryUtilizationAvg, err = parseOptionalFloat(row[3]); err != nil {
+			return nil, err
+		}
+		if m.MemoryUtilizationPeak, err = parseOptionalFloat(row[4]); err != nil {
+			return nil, err
+		}
+		if m.ComputeOccupancyAvg, err = parseOptionalFloat(row[5]); err != nil {
+			return nil, err
+		}
+		if m.ComputeOccupancyPeak, err = parseOptionalFloat(row[6]); err != nil {
+			return nil, err
+		}
+		res[uuid] = m
+	}
+	return res, nil
+}
+
+func parseOptionalFloat(s string) (float64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, nil
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid nsys metric value %q: %w", s, err)
+	}
+	return v, nil
+}
+
+func normalizeGPUUUID(uuid string) string {
+	uuid = strings.TrimSpace(uuid)
+	if uuid == "" || strings.HasPrefix(uuid, "GPU-") {
+		return uuid
+	}
+	return "GPU-" + uuid
+}

--- a/gpu/nsight_test.go
+++ b/gpu/nsight_test.go
@@ -1,0 +1,72 @@
+package gpu
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseNsightMetricsCSV(t *testing.T) {
+	collectedAt := time.Unix(10, 0)
+	payload := []byte(`gpu_uuid,gpu_utilization_avg,gpu_utilization_peak,memory_utilization_avg,memory_utilization_peak,compute_occupancy_avg,compute_occupancy_peak
+63c0bd08-6466-9b69-bf0e-06388b78bfe3,12.5,35,4.25,10,3.5,7
+GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee,0,1,2,3,4,5
+`)
+
+	metrics, err := parseNsightMetricsCSV(payload, collectedAt)
+	require.NoError(t, err)
+	require.Len(t, metrics, 2)
+
+	m := metrics["GPU-63c0bd08-6466-9b69-bf0e-06388b78bfe3"]
+	require.Equal(t, 12.5, m.GPUUtilizationAvg)
+	require.Equal(t, float64(35), m.GPUUtilizationPeak)
+	require.Equal(t, 4.25, m.MemoryUtilizationAvg)
+	require.Equal(t, float64(10), m.MemoryUtilizationPeak)
+	require.Equal(t, 3.5, m.ComputeOccupancyAvg)
+	require.Equal(t, float64(7), m.ComputeOccupancyPeak)
+	require.Equal(t, collectedAt, m.CollectedAt)
+
+	require.Contains(t, metrics, "GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+}
+
+func TestParseNsightMetricsCSVAllowsMissingValues(t *testing.T) {
+	payload := []byte(`gpu_uuid,gpu_utilization_avg,gpu_utilization_peak,memory_utilization_avg,memory_utilization_peak,compute_occupancy_avg,compute_occupancy_peak
+63c0bd08-6466-9b69-bf0e-06388b78bfe3,,,,,,
+`)
+
+	metrics, err := parseNsightMetricsCSV(payload, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, float64(0), metrics["GPU-63c0bd08-6466-9b69-bf0e-06388b78bfe3"].GPUUtilizationAvg)
+}
+
+func TestNewNsightCollectorRequiresNvidiaGPU(t *testing.T) {
+	c, err := newNsightCollector(nil)
+	require.Nil(t, c)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no NVIDIA GPUs detected")
+}
+
+func TestNsightCommandPathForHostNsight(t *testing.T) {
+	hostNsys := "/proc/1/root/opt/nvidia/nsight-systems/2025.6.3/target-linux-x64/nsys"
+
+	require.True(t, nsightRunsOnHost(hostNsys))
+	require.Equal(t, "/opt/nvidia/nsight-systems/2025.6.3/target-linux-x64/nsys", nsightCommandPath(hostNsys, hostNsys))
+	require.Equal(t, "/tmp/coroot-nsys-123/gpu", nsightCommandPath(hostNsys, "/proc/1/root/tmp/coroot-nsys-123/gpu"))
+	require.Equal(t, "/tmp/coroot-nsys-123/gpu", nsightCommandPath("/usr/bin/nsys", "/tmp/coroot-nsys-123/gpu"))
+}
+
+func TestNsightCollectorLive(t *testing.T) {
+	if os.Getenv("COROOT_TEST_NSIGHT") != "1" {
+		t.Skip("set COROOT_TEST_NSIGHT=1 to run against a local Nsight Systems installation")
+	}
+	nsysPath, err := findNsightSystemsCLI()
+	require.NoError(t, err)
+	require.NoError(t, checkNsightGPUMetrics(nsysPath))
+
+	c := &nsightCollector{nsysPath: nsysPath, interval: 3 * time.Second}
+	metrics, err := c.collect()
+	require.NoError(t, err)
+	require.NotEmpty(t, metrics)
+}


### PR DESCRIPTION
## Summary

This adds an Nsight Systems GPU metrics path for node-level NVIDIA GPU telemetry while keeping the existing NVML path as the fallback.

GPU hosts deserve special treatment in Coroot because the accelerator is usually the scarce and expensive resource on the node. CPU and memory can look healthy while an enterprise GPU fleet is either idle, bottlenecked, or saturated. For teams paying for H100/A100/L40-class instances or on-prem accelerator capacity, utilization and occupancy are core signals for capacity planning, workload placement, and return on infrastructure spend.

## What changed

- Detects a usable `nsys` binary from the container path or host-mounted Nsight Systems installations and validates that GPU metrics are available before enabling the collector.
- Runs a short periodic Nsight Systems capture aligned with the scrape interval and extracts GPU metrics through a custom `nsys stats` report.
- Uses Nsight GPU metrics for node-level average and peak GPU utilization from `GR Active [Throughput %]`.
- Uses Nsight DRAM read/write bandwidth metrics for node-level average and peak GPU memory utilization.
- Adds new node-level compute occupancy metrics:
  - `node_resources_gpu_compute_occupancy_percent_avg`
  - `node_resources_gpu_compute_occupancy_percent_peak`
- Keeps NVML for GPU inventory, memory totals/used bytes, temperature, power, process/container utilization samples, and fallback node utilization when Nsight is not installed, unsupported, or stale.
- Handles host-installed Nsight Systems by chrooting into `/proc/1/root` when needed so generated reports and paths resolve correctly on the host filesystem.
- Adds unit coverage for Nsight CSV parsing, UUID normalization, host path translation, and the no-GPU guard; leaves the live Nsight integration test opt-in via `COROOT_TEST_NSIGHT=1`.

## Why utilization and occupancy both matter

GPU utilization is the first signal that expensive accelerator capacity is doing work, but it does not fully explain whether kernels are keeping the device effectively occupied. Compute occupancy adds the missing enterprise operations signal: it helps distinguish work that merely touches the GPU from work that keeps streaming multiprocessors busy. Together with memory bandwidth utilization, these metrics make it easier to identify idle GPUs, memory-bound workloads, inefficient kernels, and saturation before the only visible symptom is poor application throughput.

## Companion UI work

Companion Coroot UI/backend PR: coroot/coroot#888. That PR consumes the compute occupancy metrics added here and surfaces GPU utilization, memory utilization, and SM occupancy in the Nodes overview and GPU audit views.

## Testing

- `docker run --rm -v "$PWD":/src -w /src golang:1.25-bookworm sh -c 'apt-get update >/tmp/apt-update.log && apt-get install -y libsystemd-dev >/tmp/apt-install.log && /usr/local/go/bin/go test ./...'`
- Not run by default: `COROOT_TEST_NSIGHT=1 go test ./gpu -run TestNsightCollectorLive`, because it requires a GPU host with Nsight Systems installed.