### PR TITLE
fix: clear stale tail buffer after log rotation

### DIFF
--- a/logs/tail_reader.go
+++ b/logs/tail_reader.go
@@ -59,7 +59,9 @@ func NewTailReader(fileName string, ch chan<- logparser.LogEntry) (*TailReader, 
 				line, err := r.reader.ReadString('\n')
 				if err != nil {
 					prefix = line
-					r.poll(ctx)
+					if r.poll(ctx) {
+						prefix = ""
+					}
 					continue
 				}
 				if prefix != "" {
@@ -87,13 +89,13 @@ func (r *TailReader) Stop() {
 	}
 }
 
-func (r *TailReader) poll(ctx context.Context) {
+func (r *TailReader) poll(ctx context.Context) bool {
 	ticker := time.NewTicker(tailPollInterval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return false
 		case <-ticker.C:
 			if info, err := os.Stat(r.fileName); err != nil {
 				if r.file != nil {
@@ -109,11 +111,15 @@ func (r *TailReader) poll(ctx context.Context) {
 					r.file = f
 					r.info = info
 					r.reader = bufio.NewReader(r.file)
-					return
+					return true
 				}
-				if r.moved(info) || r.truncated(info) || r.appended(info) {
+				if r.moved(info) || r.truncated(info) {
 					r.info = info
-					return
+					return true
+				}
+				if r.appended(info) {
+					r.info = info
+					return false
 				}
 			}
 		}

--- a/logs/tail_reader_test.go
+++ b/logs/tail_reader_test.go
@@ -50,6 +50,17 @@ func TestTailReader(t *testing.T) {
 	get("foo 2")
 	get("bar 2")
 
+	// partial line should not leak into a rotated file
+	write("stale-prefix")
+	wait()
+	err = os.Rename(f.Name(), f.Name()+".partial")
+	assert.NoError(t, err)
+	defer os.Remove(f.Name() + ".partial")
+	f, err = os.Create(f.Name())
+	assert.NoError(t, err)
+	write("fresh line\n")
+	get("fresh line")
+
 	// move
 	err = os.Rename(f.Name(), f.Name()+".1")
 	assert.NoError(t, err)


### PR DESCRIPTION
If a tailed file ends with a partial line and gets rotated or recreated, the old prefix leaks into the first line of the new file. You get `stale-prefixfresh line`. Pretty easy to hit in the wild with container log rotation.

This clears the buffered prefix on rotate, truncate, and recreate. Normal append still keeps partial lines, so that bit stays the same.

Repro
1. Start `TailReader`
2. Write `stale-prefix` without `\n`
3. Rotate or recreate the file
4. Write `fresh line\n`
5. Before: `stale-prefixfresh line`
6. After: `fresh line`

Tested with `go test tail_reader.go tail_reader_test.go -run TestTailReader -count=3`