### PR TITLE
fix: resolve volume names for statically provisioned PersistentVolumes

### DIFF
--- a/common/volumes.go
+++ b/common/volumes.go
@@ -6,12 +6,19 @@ import (
 
 var (
 	k8sVolumeDir = regexp.MustCompile(`.+(pvc-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}).*`)
+
+	// kubelet mounts persistent volumes at /var/lib/kubelet/pods/<pod-uid>/volumes/kubernetes.io~<plugin>/<pv-name>/...,
+	// where <pv-name> is `pvc-<uuid>` only for dynamically provisioned volumes;
+	// statically provisioned volumes keep their user-defined names
+	k8sPersistentVolumeDir = regexp.MustCompile(`/volumes/kubernetes\.io~(?:csi|aws-ebs|gce-pd|azure-disk|azure-file|nfs|iscsi|rbd|cephfs|fc|portworx-volume|vsphere-volume|local-volume)/([^/]+)`)
 )
 
 func ParseKubernetesVolumeSource(source string) string {
-	groups := k8sVolumeDir.FindStringSubmatch(source)
-	if len(groups) != 2 {
-		return ""
+	if groups := k8sVolumeDir.FindStringSubmatch(source); len(groups) == 2 {
+		return groups[1]
 	}
-	return groups[1]
+	if groups := k8sPersistentVolumeDir.FindStringSubmatch(source); len(groups) == 2 {
+		return groups[1]
+	}
+	return ""
 }

--- a/common/volumes_test.go
+++ b/common/volumes_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestParseKubernetesVolumeSource(t *testing.T) {
+	// dynamically provisioned volumes (pv name is pvc-<uuid>)
 	assert.Equal(t,
 		"pvc-90af9c02-ec70-446a-a16a-3ce17d4f42b4",
 		ParseKubernetesVolumeSource("/var/lib/kubelet/pods/ed56844b-2ad5-4858-9305-abea47bd39fc/volumes/kubernetes.io~csi/pvc-90af9c02-ec70-446a-a16a-3ce17d4f42b4/mount"),
@@ -23,6 +24,25 @@ func TestParseKubernetesVolumeSource(t *testing.T) {
 		"pvc-4bf620ab-bb10-4cd6-803a-5be8735ccaf6",
 		ParseKubernetesVolumeSource("/var/snap/microk8s/common/default-storage/coroot-coroot-data-pvc-4bf620ab-bb10-4cd6-803a-5be8735ccaf6"))
 
+	// statically provisioned volumes (user-defined pv names)
+	assert.Equal(t,
+		"vls-restore",
+		ParseKubernetesVolumeSource("/var/lib/kubelet/pods/2c1f8c7a-3a37-4e94-9d2b-0a4f9f8a1b6e/volumes/kubernetes.io~csi/vls-restore/mount"),
+	)
+	assert.Equal(t,
+		"ledger-migration",
+		ParseKubernetesVolumeSource("/var/lib/kubelet/pods/7f1d2b9e-8c44-4a0d-b1de-3f6f0c9f2a51/volumes/kubernetes.io~csi/ledger-migration/mount"),
+	)
+	assert.Equal(t,
+		"data-on-nfs",
+		ParseKubernetesVolumeSource("/var/lib/kubelet/pods/9a2b3c4d-5e6f-4a1b-8c9d-0e1f2a3b4c5d/volumes/kubernetes.io~nfs/data-on-nfs"),
+	)
+	assert.Equal(t,
+		"legacy-ebs-volume",
+		ParseKubernetesVolumeSource("/var/lib/kubelet/pods/1b2c3d4e-5f6a-4b1c-9d8e-7f0a1b2c3d4e/volumes/kubernetes.io~aws-ebs/legacy-ebs-volume"),
+	)
+
+	// non-persistent volume plugins must not produce a volume name
 	assert.Equal(t,
 		"",
 		ParseKubernetesVolumeSource("/var/lib/kubelet/pods/adf669ca-c3f8-49de-9ad4-9dd66721dc0d/volumes/kubernetes.io~projected/kube-api-access-jvvq6"),
@@ -34,5 +54,21 @@ func TestParseKubernetesVolumeSource(t *testing.T) {
 	assert.Equal(t,
 		"",
 		ParseKubernetesVolumeSource("/var/lib/kubelet/pods/db6e284a-fbab-4629-8f17-9f5fea38bea7/volumes/kubernetes.io~configmap/config-volume"),
+	)
+	assert.Equal(t,
+		"",
+		ParseKubernetesVolumeSource("/var/lib/kubelet/pods/db6e284a-fbab-4629-8f17-9f5fea38bea7/volumes/kubernetes.io~secret/tls-certs"),
+	)
+	assert.Equal(t,
+		"",
+		ParseKubernetesVolumeSource("/var/lib/kubelet/pods/db6e284a-fbab-4629-8f17-9f5fea38bea7/volumes/kubernetes.io~empty-dir/tmp"),
+	)
+	assert.Equal(t,
+		"",
+		ParseKubernetesVolumeSource("/var/lib/kubelet/pods/db6e284a-fbab-4629-8f17-9f5fea38bea7/volumes/kubernetes.io~downward-api/podinfo"),
+	)
+	assert.Equal(t,
+		"",
+		ParseKubernetesVolumeSource("/var/lib/docker/overlay2/0a1b2c3d4e5f/merged"),
 	)
 }


### PR DESCRIPTION
Fixes coroot/coroot#915

### Problem

`ParseKubernetesVolumeSource` only extracts a volume name when the mount source
path contains a `pvc-<uuid>` segment — the naming scheme of *dynamically*
provisioned PersistentVolumes. Statically provisioned PVs keep their
user-defined names (e.g. `vls-restore`, `ledger-migration`), so for them the
`volume` label of all `container_resources_disk_*` metrics is emitted empty.

On the Coroot server side, `auditor/storage.go` skips Kubernetes volumes with
an empty name and deletes the whole Storage report when none remain — so any
app running on a statically provisioned PV silently gets **no Storage tab at
all**, even though the agent collects and ships all of its disk metrics.

### Fix

Keep the existing `pvc-<uuid>` regex as the primary match (it also covers
k3s/microk8s local-path and `volume-subpaths` layouts), and add a fallback
that extracts the PV name from the standard kubelet mount path:

```
/var/lib/kubelet/pods/<pod-uid>/volumes/kubernetes.io~<plugin>/<pv-name>[/mount]
```

The fallback is restricted to persistent-volume plugins (`csi`, `aws-ebs`,
`gce-pd`, `azure-disk`, `azure-file`, `nfs`, `iscsi`, `rbd`, `cephfs`, `fc`,
`portworx-volume`, `vsphere-volume`, `local-volume`), so ephemeral volume
types (`configmap`, `secret`, `projected`, `empty-dir`, `downward-api`) still
return an empty name, preserving current behavior.

### Testing

Extended `TestParseKubernetesVolumeSource`:

- positive, dynamically provisioned (`pvc-<uuid>`): CSI, `volume-subpaths`, k3s and microk8s paths — unchanged behavior;
- positive, statically provisioned (custom names): CSI (`vls-restore`, `ledger-migration`), in-tree `aws-ebs`, and `nfs`;
- negative: `projected`, `configmap`, `secret`, `empty-dir`, `downward-api`, `etc-hosts`, and a non-kubelet overlayfs path — all return `""`.

`go test ./common/` and `go vet ./common/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
