### PR TITLE
Add delay timer when attaching go tls uprobes to a process

### DIFF
--- a/containers/container.go
+++ b/containers/container.go
@@ -1436,6 +1436,20 @@ func (c *Container) attachTlsUprobes(tracer *ebpftracer.Tracer, pid uint32) {
 	if p == nil {
 		return
 	}
+	if delay := *flags.TlsInstrumentationDelay; delay > 0 && !p.StartedAt.IsZero() {
+		if wait := delay - time.Since(p.StartedAt); wait > 0 {
+			p.tlsDelayLock.Lock()
+			if p.tlsDelayTimer == nil {
+				p.tlsDelayTimer = time.AfterFunc(wait, func() {
+					c.attachTlsUprobes(tracer, pid)
+				})
+			}
+			p.tlsDelayLock.Unlock()
+			return
+		}
+	}
+	p.tlsDelayLock.Lock()
+	defer p.tlsDelayLock.Unlock()
 	if !p.openSslUprobesChecked {
 		if key := tracer.AttachOpenSslUprobes(pid); key != nil {
 			p.addUprobeKey(*key)

--- a/containers/process.go
+++ b/containers/process.go
@@ -56,6 +56,9 @@ type Process struct {
 	nodejsPrevStats       *ebpftracer.NodejsStats
 	pythonPrevStats       *ebpftracer.PythonStats
 
+	tlsDelayLock  sync.Mutex
+	tlsDelayTimer *time.Timer
+
 	gpuUsageSamples []gpu.ProcessUsageSample
 
 	inboundHttp2Parsers map[uint64]*inboundHttp2State
@@ -215,6 +218,11 @@ func (p *Process) addUprobeKey(key ebpftracer.UprobeKey) {
 
 func (p *Process) Close() {
 	p.cancelFunc()
+	p.tlsDelayLock.Lock()
+	if p.tlsDelayTimer != nil {
+		p.tlsDelayTimer.Stop()
+	}
+	p.tlsDelayLock.Unlock()
 	<-p.instrumentDone
 	p.uprobeKeysLock.Lock()
 	p.closed = true

--- a/flags/flags_linux.go
+++ b/flags/flags_linux.go
@@ -21,6 +21,7 @@ var (
 	JavaAsyncProfilerDelay  = kingpin.Flag("java-async-profiler-delay", "Delay in seconds before starting async-profiler after JVM process is detected").Default("30s").Envar("JAVA_ASYNC_PROFILER_DELAY").Duration()
 	GoHeapProfilerMode      = kingpin.Flag("go-heap-profiler", "Go heap profiling mode: disabled, enabled (collect from apps with profiling on), force (enable profiling in all Go apps)").Default("enabled").Envar("GO_HEAP_PROFILER").String()
 	InstrumentationDelay    = kingpin.Flag("instrumentation-delay", "Delay before enabling Python GIL and Node.js event loop instrumentation, after a process is started").Default("30s").Envar("INSTRUMENTATION_DELAY").Duration()
+	TlsInstrumentationDelay = kingpin.Flag("tls-instrumentation-delay", "Delay before attaching TLS uprobes to a process, to skip short-lived processes (e.g., exec probes)").Default("5s").Envar("TLS_INSTRUMENTATION_DELAY").Duration()
 
 	SkipSystemdSystemServices = kingpin.Flag("skip-systemd-system-services", "Skip well-known systemd system containers (apt, motd, udev, etc.)").Default("true").Envar("SKIP_SYSTEMD_SYSTEM_SERVICES").Bool()
 


### PR DESCRIPTION
Added TlsInstrumentationDelay flag (default 5s) to skip TLS uprobe attachment for short-lived processes (e.g., exec probes). When a process is younger than the timeperiod, uprobe attachment is delayed  instead of running immediately.

This way, we can skip attaching uprobes for short process like liveliness/readiness probes