### PR TITLE
Add flags to disable irrelevant integrations

### DIFF
--- a/containers/cilium.go
+++ b/containers/cilium.go
@@ -34,7 +34,11 @@ var ciliumMaps = map[string]ciliumMapDefinition{
 	lbmap.Backend6MapV3Name: {key: &lbmap.Backend6KeyV3{}, value: &lbmap.Backend6ValueV3{}},
 }
 
-func init() {
+// InitCilium probes the host BPF filesystem for Cilium's conntrack and
+// load-balancer maps. It is called explicitly after flag parsing (rather than
+// from a package init) so it can be skipped via --no-cilium and so the probe
+// order stays consistent with the other integrations set up in NewRegistry.
+func InitCilium() {
 	var err error
 
 	ciliumCt4, err = bpf.OpenMap(

--- a/containers/registry.go
+++ b/containers/registry.go
@@ -96,8 +96,10 @@ func NewRegistry(reg prometheus.Registerer, processInfoCh chan<- ProcessInfo, pr
 	if err = cgroup.Init(); err != nil {
 		return nil, err
 	}
-	if err = DockerdInit(); err != nil {
-		klog.Warningln(err)
+	if !*flags.DisableDockerd {
+		if err = DockerdInit(); err != nil {
+			klog.Warningln(err)
+		}
 	}
 	if err = ContainerdInit(); err != nil {
 		klog.Warningln(err)
@@ -105,8 +107,13 @@ func NewRegistry(reg prometheus.Registerer, processInfoCh chan<- ProcessInfo, pr
 	if err = CrioInit(); err != nil {
 		klog.Warningln(err)
 	}
-	if err = JournaldInit(); err != nil {
-		klog.Warningln(err)
+	if !*flags.DisableJournald {
+		if err = JournaldInit(); err != nil {
+			klog.Warningln(err)
+		}
+	}
+	if !*flags.DisableCilium {
+		InitCilium()
 	}
 
 	r := &Registry{
@@ -584,6 +591,9 @@ func calcId(cg *cgroup.Cgroup, md *ContainerMetadata) ContainerID {
 func getContainerMetadata(cg *cgroup.Cgroup) (*ContainerMetadata, error) {
 	switch cg.ContainerType {
 	case cgroup.ContainerTypeSystemdService:
+		if *flags.DisableSystemd {
+			return &ContainerMetadata{}, nil
+		}
 		var err error
 		md := &ContainerMetadata{}
 		md.systemd, err = getSystemdProperties(cg.Id)

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -17,6 +17,7 @@ var (
 
 	DisableLogParsing    = kingpin.Flag("disable-log-parsing", "Disable container log parsing").Default("false").Envar(envar("DISABLE_LOG_PARSING")).Bool()
 	DisableGPUMonitoring = kingpin.Flag("disable-gpu-monitoring", "Disable GPU monitoring (NVML)").Default("false").Envar(envar("DISABLE_GPU_MONITORING")).Bool()
+	DisableCloudMetadata = kingpin.Flag("no-cloud-metadata", "Don't query the cloud metadata service. The provider is auto-detected per node by default, so this is only needed to force it off (locked-down or misdetected nodes)").Default("false").Envar(envar("NO_CLOUD_METADATA")).Bool()
 
 	ContainerAllowlist = kingpin.Flag("container-allowlist", "List of allowed containers (regex patterns)").Envar(envar("CONTAINER_ALLOWLIST")).Strings()
 	ContainerDenylist  = kingpin.Flag("container-denylist", "List of denied containers (regex patterns)").Envar(envar("CONTAINER_DENYLIST")).Strings()
@@ -28,7 +29,7 @@ var (
 	ExternalNetworksWhitelist = kingpin.Flag("track-public-network", "Allow track connections to the specified IP networks, all private networks are allowed by default (e.g., Y.Y.Y.Y/mask)").Envar(envar("TRACK_PUBLIC_NETWORK")).Default("0.0.0.0/0").Strings()
 	EphemeralPortRange        = kingpin.Flag("ephemeral-port-range", "Destination and Listen TCP ports from this range will be skipped").Default("32768-60999").Envar(envar("EPHEMERAL_PORT_RANGE")).String()
 
-	Provider          = kingpin.Flag("provider", "`provider` label for `node_cloud_info` metric").Envar(envar("PROVIDER")).String()
+	Provider          = kingpin.Flag("provider", "Cloud provider (aws, gcp, azure, hetzner, digitalocean, alibaba, scaleway, ibm, oracle). Sets the `provider` label and forces the metadata service of that provider to be queried, overriding per-node auto-detection").Envar(envar("PROVIDER")).String()
 	Region            = kingpin.Flag("region", "`region` label for `node_cloud_info` metric").Envar(envar("REGION")).String()
 	AvailabilityZone  = kingpin.Flag("availability-zone", "`availability_zone` label for `node_cloud_info` metric").Envar(envar("AVAILABILITY_ZONE")).String()
 	InstanceType      = kingpin.Flag("instance-type", "`instance_type` label for `node_cloud_info` metric").Envar(envar("INSTANCE_TYPE")).String()

--- a/flags/flags_linux.go
+++ b/flags/flags_linux.go
@@ -24,6 +24,11 @@ var (
 
 	SkipSystemdSystemServices = kingpin.Flag("skip-systemd-system-services", "Skip well-known systemd system containers (apt, motd, udev, etc.)").Default("true").Envar("SKIP_SYSTEMD_SYSTEM_SERVICES").Bool()
 
+	DisableDockerd  = kingpin.Flag("no-docker", "Don't probe the Docker daemon socket (useful on nodes with no Docker, e.g. Bottlerocket)").Default("false").Envar("NO_DOCKER").Bool()
+	DisableSystemd  = kingpin.Flag("no-systemd", "Don't query systemd unit properties over D-Bus (useful where the host SELinux policy denies access)").Default("false").Envar("NO_SYSTEMD").Bool()
+	DisableJournald = kingpin.Flag("no-journald", "Don't read the systemd journal").Default("false").Envar("NO_JOURNALD").Bool()
+	DisableCilium   = kingpin.Flag("no-cilium", "Don't attach to Cilium eBPF maps (useful on nodes not running Cilium)").Default("false").Envar("NO_CILIUM").Bool()
+
 	LogPerSecond = kingpin.Flag("log-per-second", "The number of logs per second").Default("10.0").Envar("LOG_PER_SECOND").Float64()
 	LogBurst     = kingpin.Flag("log-burst", "The maximum number of tokens that can be consumed in a single call to allow").Default("100").Envar("LOG_BURST").Int()
 

--- a/main.go
+++ b/main.go
@@ -118,11 +118,12 @@ func main() {
 	}, machineId, hostname, version)
 
 	nodeCollector := node.NewCollector(hostname, kv, metadata.Overrides{
-		Provider:          flags.GetString(flags.Provider),
-		Region:            flags.GetString(flags.Region),
-		AvailabilityZone:  flags.GetString(flags.AvailabilityZone),
-		InstanceType:      flags.GetString(flags.InstanceType),
-		InstanceLifeCycle: flags.GetString(flags.InstanceLifeCycle),
+		Provider:             flags.GetString(flags.Provider),
+		Region:               flags.GetString(flags.Region),
+		AvailabilityZone:     flags.GetString(flags.AvailabilityZone),
+		InstanceType:         flags.GetString(flags.InstanceType),
+		InstanceLifeCycle:    flags.GetString(flags.InstanceLifeCycle),
+		DisableCloudMetadata: *flags.DisableCloudMetadata,
 	})
 
 	registry := prometheus.NewRegistry()

--- a/node/collector.go
+++ b/node/collector.go
@@ -14,7 +14,7 @@ type Collector struct {
 }
 
 func NewCollector(hostname, kernelVersion string, overrides metadata.Overrides) *Collector {
-	md := metadata.GetInstanceMetadata()
+	md := metadata.GetInstanceMetadata(overrides)
 	if md == nil {
 		md = &metadata.CloudMetadata{}
 	}

--- a/node/metadata/detect.go
+++ b/node/metadata/detect.go
@@ -1,9 +1,26 @@
 package metadata
 
-import "strings"
+import (
+	"strings"
 
-func GetInstanceMetadata() *CloudMetadata {
-	return GetMetadata(getCloudProvider())
+	"k8s.io/klog/v2"
+)
+
+func GetInstanceMetadata(o Overrides) *CloudMetadata {
+	if o.DisableCloudMetadata {
+		klog.Infoln("cloud metadata service querying is disabled")
+		return &CloudMetadata{}
+	}
+	provider := getCloudProvider()
+	// An explicitly configured provider is an intentional, per-deployment
+	// override (e.g. a DaemonSet pinned to a specific node pool). Honor it even
+	// when auto-detection disagrees or is inconclusive. When left empty the
+	// per-node auto-detection result is used, which is the right default for
+	// hybrid clusters spanning several clouds and bare metal.
+	if o.Provider != "" {
+		provider = CloudProvider(o.Provider)
+	}
+	return GetMetadata(provider)
 }
 
 func cloudProviderByVendor(boardVendor, sysVendor string) CloudProvider {

--- a/node/metadata/metadata.go
+++ b/node/metadata/metadata.go
@@ -39,11 +39,12 @@ type CloudMetadata struct {
 }
 
 type Overrides struct {
-	Provider          string
-	Region            string
-	AvailabilityZone  string
-	InstanceType      string
-	InstanceLifeCycle string
+	Provider             string
+	Region               string
+	AvailabilityZone     string
+	InstanceType         string
+	InstanceLifeCycle    string
+	DisableCloudMetadata bool
 }
 
 func (md *CloudMetadata) ApplyOverrides(o Overrides) {


### PR DESCRIPTION
Adds opt-in flags to skip integrations that are irrelevant on a given node, so the agent doesn't probe them or report them as unavailable. Companion to #327 (which quiets the benign log lines); this PR lets operators turn the probes off entirely.

New flags (all default to current behavior — auto-detect):

| flag | env | effect |
|------|-----|--------|
| `--no-docker` | `NO_DOCKER` | don't probe the Docker daemon socket |
| `--no-systemd` | `NO_SYSTEMD` | don't query systemd unit properties over D-Bus |
| `--no-journald` | `NO_JOURNALD` | don't read the systemd journal |
| `--no-cilium` | `NO_CILIUM` | don't attach to Cilium eBPF maps |
| `--no-cloud-metadata` | `NO_CLOUD_METADATA` | don't query the cloud metadata service |

**Hybrid clusters.** Defaults are unchanged: every integration is auto-detected per node, and the cloud provider is detected from DMI per node. That is deliberately the recommended mode for clusters spanning several clouds and bare metal — a single DaemonSet works everywhere. The flags are escape hatches for homogeneous node pools (typically deployed as a pool-scoped DaemonSet via `nodeSelector`) or locked-down / misdetected environments.

**`--provider` now forces the probe.** Previously `--provider` only set the `node_cloud_info` label. It now also forces the metadata service of that provider to be queried, overriding auto-detection, so a real cloud node whose DMI is not readable still gets its instance metadata. An empty value keeps per-node auto-detection.

**Cilium init.** The Cilium map probing is moved out of a package `init()` into `InitCilium()`, called after flag parsing from `NewRegistry` — so it can be gated by `--no-cilium` and lines up with how the other integrations (docker/containerd/cri-o/journald) are already initialized.

No behavior change with default flags; builds for linux and windows.
