### PR TITLE
build: bump pyroscope/ebpf fork for CPython 3.14 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -222,7 +222,7 @@ require (
 )
 
 replace (
-	github.com/grafana/pyroscope/ebpf => github.com/coroot/pyroscope/ebpf v0.0.0-20260413145227-9cce3f956c8e
+	github.com/grafana/pyroscope/ebpf => github.com/gecube/pyroscope/ebpf v0.0.0-20260706122038-22b69c8c6af6
 	github.com/optiopay/kafka => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b
 	github.com/pyroscope-io/dotnetdiag => github.com/coroot/dotnetdiag v1.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,6 @@ github.com/coroot/dotnetdiag v1.2.2 h1:PVP/By8o+xhPjfVolJYcjHLbFQInM7pkaD6/otPLc
 github.com/coroot/dotnetdiag v1.2.2/go.mod h1:veXCMlFzm1yNl7wwJb/ZLxO4WbzhDBoy1VG1XtkH2ls=
 github.com/coroot/logparser v1.2.1 h1:NLU4VAgGwqMTtKyRHDpTtE9BtPQJLOhDIuB5yiQdelQ=
 github.com/coroot/logparser v1.2.1/go.mod h1:/7qHU4/I4zWRYIzRchQPehlTzbcMv5HV6cwBqg2zl6I=
-github.com/coroot/pyroscope/ebpf v0.0.0-20260413145227-9cce3f956c8e h1:nV+56pdT5ikl84ZcIoyb5qHWXuSZip2DZNFqIAs2XM0=
-github.com/coroot/pyroscope/ebpf v0.0.0-20260413145227-9cce3f956c8e/go.mod h1:IepHM9FJ0n3n3k+ZV23Y7vNAfvWI7LDuLqWPO4rB6sQ=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cyphar/filepath-securejoin v0.6.0 h1:BtGB77njd6SVO6VztOHfPxKitJvd/VPT+OFBFMOi1Is=
 github.com/cyphar/filepath-securejoin v0.6.0/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
@@ -140,6 +138,8 @@ github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
+github.com/gecube/pyroscope/ebpf v0.0.0-20260706122038-22b69c8c6af6 h1:+KLtz2DlLU0+6yE279ZXtbPDsSswptdvOCEn1cHZ26s=
+github.com/gecube/pyroscope/ebpf v0.0.0-20260706122038-22b69c8c6af6/go.mod h1:IepHM9FJ0n3n3k+ZV23Y7vNAfvWI7LDuLqWPO4rB6sQ=
 github.com/go-faster/city v1.0.1 h1:4WAxSZ3V2Ws4QRDrscLEDcibJY8uf41H6AhXDrNDcGw=
 github.com/go-faster/city v1.0.1/go.mod h1:jKcUJId49qdW3L1qKHH/3wPeUstCVpVSXTM6vO3VcTw=
 github.com/go-faster/errors v0.7.1 h1:MkJTnDoEdi9pDabt1dpWf7AA8/BaSYZqibYyhZ20AYg=


### PR DESCRIPTION
> **Draft — blocked on coroot/pyroscope#3.**
> The Python 3.14 offsets live in the pyroscope eBPF fork. This PR just bumps the `replace` pin so node-agent picks them up. It's temporarily pinned to the PR branch commit; once coroot/pyroscope#3 merges I'll repoint it to the `coroot/pyroscope` commit and mark ready.

## What

Python 3.14 processes aren't profiled today: the eBPF Python unwinder (from `github.com/grafana/pyroscope/ebpf`, `replace`d with the `coroot/pyroscope` fork) has no offset table for 3.14, so `GetUserOffsets` returns `unsupported version` and no profiles are produced. Reported in #318.

This bumps the fork pin to the commit that adds the CPython 3.14 offset table:

```
-  github.com/grafana/pyroscope/ebpf => github.com/coroot/pyroscope/ebpf v0.0.0-20260413145227-9cce3f956c8e
+  github.com/grafana/pyroscope/ebpf => github.com/gecube/pyroscope/ebpf v0.0.0-20260706122038-22b69c8c6af6
```

(pyroscope-side change: coroot/pyroscope#3)

## Verification

- `go mod tidy` clean; `go build ./profiling/` and `go vet ./profiling/` pass with the bumped dependency.
- Runtime A/B against a live `python:3.14.6` process (same PID), eBPF session with `PythonEnabled`:
  - before: `pyperf get python process data failed err="unsupported python version ... {3 14 6}"`
  - after: `pyperf process profiling init success ... Version:{Major:3 Minor:14 Patch:6}`

## Before marking ready

- [ ] coroot/pyroscope#3 merged
- [ ] repoint `replace` from the `gecube` fork commit to the `coroot/pyroscope` commit
- [ ] `go mod tidy`

Fixes #318.
