### PR TITLE
Do not log client scrape disconnects as errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -220,7 +221,22 @@ func info(name, version string) prometheus.Collector {
 type logger struct{}
 
 func (l logger) Println(v ...interface{}) {
+	for _, arg := range v {
+		if err, ok := arg.(error); ok && isClientDisconnect(err) {
+			// A scraper (e.g. Prometheus) closed the connection before the
+			// /metrics response was fully written. This is benign - usually a
+			// scrape timeout or the scraper restarting - and promhttp reports it
+			// once per metric family, so keep it out of the error stream to avoid
+			// log spam.
+			klog.V(1).Infoln(v...)
+			return
+		}
+	}
 	klog.Errorln(v...)
+}
+
+func isClientDisconnect(err error) bool {
+	return errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET)
 }
 
 type RateLimitedLogOutput struct {


### PR DESCRIPTION
## Problem

When a scraper (e.g. Prometheus) closes the `/metrics` connection before the response is fully written, `promhttp` invokes the configured `ErrorLog` **once per metric family**. A single benign event — a scrape timeout or the scraper restarting — floods the log with dozens of identical lines:

```
E... main.go:...] error encoding and sending metric family: write tcp 10.244.2.225:80->10.244.0.63:47976: write: broken pipe
E... main.go:...] error encoding and sending metric family: write tcp 10.244.2.225:80->10.244.0.63:47976: write: broken pipe
...
```

This is a client-side disconnect (the agent is being scraped and the peer went away mid-response), not an agent fault, but it is reported at error level and is easily mistaken for a real failure. See #289.

## Change

Detect `EPIPE`/`ECONNRESET` in the promhttp error logger and log those at `V(1)` instead of the error stream. Genuine encoding/gathering errors continue to be logged as errors.