### PR TITLE
flags: respect explicit --listen when metrics-endpoint is set

### DIFF
--- a/flags/flags.go
+++ b/flags/flags.go
@@ -83,7 +83,11 @@ func init() {
 		platformEndpoints(u)
 	}
 
-	if *MetricsEndpoint != nil {
+	if *MetricsEndpoint != nil && *ListenAddress == defaultListenAddress {
+		// In remote-write mode the built-in HTTP server is only needed for the
+		// agent's own metrics, so bind it to loopback by default. Respect an
+		// explicitly configured --listen/LISTEN so /metrics can also be scraped
+		// directly (e.g. by an external Prometheus alongside remote write).
 		*ListenAddress = "127.0.0.1:10300"
 	}
 }


### PR DESCRIPTION
## Problem

Fixes #258.

When a metrics endpoint is configured — either directly via `--metrics-endpoint` / `METRICS_ENDPOINT`, or derived from `--collector-endpoint` — `flags/init()` unconditionally overwrites the listen address:

```go
if *MetricsEndpoint != nil {
    *ListenAddress = "127.0.0.1:10300"
}
```

This binds the built-in HTTP server to loopback and silently discards any user-provided `--listen` / `LISTEN`. As a result you cannot scrape `/metrics` directly from the agent while it is also remote-writing, even if you explicitly ask for a routable listen address.

## Change

Only apply the loopback default when the listen address is still at its compiled-in default:

```go
if *MetricsEndpoint != nil && *ListenAddress == defaultListenAddress {
    *ListenAddress = "127.0.0.1:10300"
}
```

- **No `--listen` set** → unchanged behavior: loopback (`127.0.0.1:10300`) in remote-write mode.
- **`--listen` / `LISTEN` set explicitly** → honored, so `/metrics` can be scraped alongside remote write.

## Why this is safe

`*flags.ListenAddress` is consumed only by the HTTP server (`main.go`, and the Windows agent). The remote-write path gathers metrics in-process via `registry.Gather()` (`prom/remote_writer.go`) — it does **not** scrape its own socket — so honoring `--listen` cannot affect the remote-write pipeline. On Windows `defaultListenAddress` is already `127.0.0.1:10300`, so the default-mode behavior there is unchanged too, and an explicit `--listen` is now honored on Windows as well.

Builds cleanly for `GOOS=linux` and `GOOS=windows`; `go vet ./flags/` is clean.