### PR TITLE
Strip debug info from the release binary (-s -w)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY go.sum .
 RUN go mod download
 COPY . .
 ARG VERSION=unknown
-RUN CGO_ENABLED=1 go build -mod=readonly -ldflags "-extldflags='-Wl,-z,lazy' -X 'github.com/coroot/coroot-node-agent/flags.Version=${VERSION}'" -o coroot-node-agent .
+RUN CGO_ENABLED=1 go build -mod=readonly -ldflags "-s -w -extldflags='-Wl,-z,lazy' -X 'github.com/coroot/coroot-node-agent/flags.Version=${VERSION}'" -o coroot-node-agent .
 
 FROM registry.access.redhat.com/ubi9/ubi
 


### PR DESCRIPTION
## What

Add `-s -w` to the build `-ldflags` so the shipped binary no longer carries the full symbol and DWARF tables.

## Why

Related to #249. The binary is currently built and released **unstripped** (`file` reports `with debug_info, not stripped`), so every release ships the `.symtab`/`.strtab` and `.debug_*` sections.

This doesn't fix the underlying growth from the `cilium/cilium` bump (that's genuinely more compiled code — `.text`/`.gopclntab`/`.rodata`), but it's a cheap, low-risk win on the packaging side.

## Verification

Built current `main` twice (Go 1.24.9), identical flags except `-s -w`:

| build | size | `file` |
|---|---|---|
| current `-ldflags` | 140.1 MB | `not stripped` |
| `+ -s -w` | 99.8 MB | `stripped` (**-28.8%**) |

Section diff — only debug/symbol tables are removed, no functional section is touched:

```
section        current   +(-s -w)
.text            40.8M     40.8M   (unchanged)
.gopclntab       34.0M     34.0M   (unchanged -> panic stack traces stay symbolized)
.rodata          23.2M     23.2M   (unchanged)
.symtab+.strtab  18.7M      0
.debug_*         21.5M      0
```

Checked on the resulting binary:
- `--version` prints the injected version, so `-ldflags -X` still works alongside `-s -w`;
- `--help` parses fine;
- `.gopclntab` is retained, so runtime panic stack traces stay symbolized.

The only capability lost is attaching gdb/delve to the shipped binary (those need DWARF).
