### PR TITLE
Add agent_version label to node_info metric

### DIFF
--- a/cmd/coroot-windows-agent/main.go
+++ b/cmd/coroot-windows-agent/main.go
@@ -78,7 +78,7 @@ func runAgent(stop <-chan struct{}) {
 		TLSConfig:   api.TlsConfig(*flags.CAFile, *flags.InsecureSkipVerify),
 	}, machineId, hostname, version)
 
-	nodeCollector := node.NewCollector(hostname, osVersion, metadata.Overrides{
+	nodeCollector := node.NewCollector(hostname, osVersion, version, metadata.Overrides{
 		Provider:          flags.GetString(flags.Provider),
 		Region:            flags.GetString(flags.Region),
 		AvailabilityZone:  flags.GetString(flags.AvailabilityZone),

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func main() {
 		TLSConfig:   api.TlsConfig(*flags.CAFile, *flags.InsecureSkipVerify),
 	}, machineId, hostname, version)
 
-	nodeCollector := node.NewCollector(hostname, kv, metadata.Overrides{
+	nodeCollector := node.NewCollector(hostname, kv, version, metadata.Overrides{
 		Provider:          flags.GetString(flags.Provider),
 		Region:            flags.GetString(flags.Region),
 		AvailabilityZone:  flags.GetString(flags.AvailabilityZone),

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -78,7 +78,7 @@ var (
 	NodeGpuTemperature     = metric("node_resources_gpu_temperature_celsius", "Current temperature of the GPU in Celsius", "gpu_uuid")
 	NodeGpuPowerWatts      = metric("node_resources_gpu_power_usage_watts", "Current power usage of the GPU in watts", "gpu_uuid")
 
-	NodeInfo            = metric("node_info", "Meta information about the node", "hostname", "kernel_version")
+	NodeInfo            = metric("node_info", "Meta information about the node", "hostname", "kernel_version", "agent_version")
 	NodeCloudInfo       = metric("node_cloud_info", "Meta information about the cloud instance", "provider", "account_id", "instance_id", "instance_type", "instance_life_cycle", "region", "availability_zone", "availability_zone_id", "local_ipv4", "public_ipv4")
 	NodeUptime          = metric("node_uptime_seconds", "Uptime of the node in seconds")
 	NodeCPUUsage        = metric("node_resources_cpu_usage_seconds_total", "The amount of CPU time spent in each mode", "mode")

--- a/node/collector.go
+++ b/node/collector.go
@@ -10,10 +10,11 @@ import (
 type Collector struct {
 	hostname         string
 	kernelVersion    string
+	agentVersion     string
 	instanceMetadata *metadata.CloudMetadata
 }
 
-func NewCollector(hostname, kernelVersion string, overrides metadata.Overrides) *Collector {
+func NewCollector(hostname, kernelVersion, agentVersion string, overrides metadata.Overrides) *Collector {
 	md := metadata.GetInstanceMetadata()
 	if md == nil {
 		md = &metadata.CloudMetadata{}
@@ -23,6 +24,7 @@ func NewCollector(hostname, kernelVersion string, overrides metadata.Overrides) 
 	return &Collector{
 		hostname:         hostname,
 		kernelVersion:    kernelVersion,
+		agentVersion:     agentVersion,
 		instanceMetadata: md,
 	}
 }

--- a/node/collector_agent_version_test.go
+++ b/node/collector_agent_version_test.go
@@ -1,0 +1,55 @@
+//go:build linux
+
+package node
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/coroot/coroot-node-agent/node/metadata"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// TestNodeInfoIncludesAgentVersion verifies that the node_info metric carries
+// the agent_version label, as documented at
+// https://docs.coroot.com/metrics/node-agent/#node_info (see issue #215).
+func TestNodeInfoIncludesAgentVersion(t *testing.T) {
+	c := &Collector{
+		hostname:         "test-host",
+		kernelVersion:    "6.1.0-test",
+		agentVersion:     "v1.2.3-test",
+		instanceMetadata: &metadata.CloudMetadata{},
+	}
+
+	ch := make(chan prometheus.Metric, 1024)
+	go func() {
+		c.Collect(ch)
+		close(ch)
+	}()
+
+	var nodeInfo *dto.Metric
+	for m := range ch {
+		if !strings.Contains(m.Desc().String(), `fqName: "node_info"`) {
+			continue
+		}
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("failed to write node_info metric: %v", err)
+		}
+		nodeInfo = &pb
+	}
+
+	if nodeInfo == nil {
+		t.Fatal("node_info metric was not emitted")
+	}
+
+	labels := map[string]string{}
+	for _, lp := range nodeInfo.Label {
+		labels[lp.GetName()] = lp.GetValue()
+	}
+
+	if got := labels["agent_version"]; got != "v1.2.3-test" {
+		t.Fatalf("node_info agent_version label = %q, want %q (all labels: %v)", got, "v1.2.3-test", labels)
+	}
+}

--- a/node/collector_linux.go
+++ b/node/collector_linux.go
@@ -35,7 +35,7 @@ type CpuUsage struct {
 }
 
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
-	ch <- metrics.Gauge(metrics.NodeInfo, 1, c.hostname, c.kernelVersion)
+	ch <- metrics.Gauge(metrics.NodeInfo, 1, c.hostname, c.kernelVersion, c.agentVersion)
 
 	v, err := uptime(procRoot)
 	if err != nil {

--- a/node/collector_windows.go
+++ b/node/collector_windows.go
@@ -18,7 +18,7 @@ import (
 )
 
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
-	ch <- metrics.Gauge(metrics.NodeInfo, 1, c.hostname, c.kernelVersion)
+	ch <- metrics.Gauge(metrics.NodeInfo, 1, c.hostname, c.kernelVersion, c.agentVersion)
 
 	if up, err := host.Uptime(); err != nil {
 		klog.Errorln("failed to get uptime:", err)


### PR DESCRIPTION
## Problem

The [`node_info` metric documentation](https://docs.coroot.com/metrics/node-agent/#node_info) lists three labels — `hostname`, `kernel_version` and `agent_version` — but the agent only ever emitted the first two. The `agent_version` label was never present, as noted in the comment on #215.

This closes the documentation/implementation gap and gives the backend the data it needs to surface the agent version in the UI and to warn when an agent falls behind (the feature requested in #215).

## Change

- Add the `agent_version` label to the `node_info` metric definition (appended last, so existing label positions are unchanged).
- Populate it with the build-time version (`flags.Version`, injected via `-ldflags -X`), passed through `node.NewCollector`.
- Update both the Linux and Windows collectors, which each emit `node_info`, so the positional label count stays consistent.

No new metric is introduced: the `node_info` info-metric is the contract the docs already promise, and its cardinality only changes across upgrades — the standard info-metric pattern.

## Verification

Unit test (`node/collector_agent_version_test.go`) asserting the label is present with the expected value:

```
=== RUN   TestNodeInfoIncludesAgentVersion
--- PASS: TestNodeInfoIncludesAgentVersion (0.00s)
PASS
ok  	github.com/coroot/coroot-node-agent/node	0.002s
```

End-to-end: image built with `--build-arg VERSION=v1.99.0-agentver-test`, run on a live host, `/metrics` scrape:

```
node_info{agent_version="v1.99.0-agentver-test",hostname="orbstack",kernel_version="7.0.11-orbstack-00360-gc9bc4d96ac70",machine_id="82ddc538b9e95ae7c1d309201ccb5f9d",system_uuid=""} 1
```

The `agent_version` label matches the build-injected version, consistent with the existing `node_agent_info{version=...}` series.

Fixes #215
