### PR TITLE
l7: bound ClickHouse parser allocations by the captured payload size

### DIFF
--- a/ebpftracer/l7/clickhouse.go
+++ b/ebpftracer/l7/clickhouse.go
@@ -2,10 +2,144 @@ package l7
 
 import (
 	"bytes"
+	"io"
 	"unicode/utf8"
 
 	"github.com/ClickHouse/ch-go/proto"
 )
+
+// chBoundedReader reads length-prefixed strings without trusting the length
+// prefix: ch-go's Reader.Str allocates make([]byte, n) before checking n
+// against the available bytes, so a misparse of a truncated capture can claim
+// a multi-gigabyte string and the allocation fires even though the read fails.
+// No string in the packet can be longer than the captured payload itself.
+type chBoundedReader struct {
+	r   *proto.Reader
+	max int
+}
+
+func (b *chBoundedReader) str() (string, error) {
+	n, err := b.r.StrLen()
+	if err != nil {
+		return "", err
+	}
+	if n > b.max {
+		return "", io.ErrUnexpectedEOF
+	}
+	if n == 0 {
+		return "", nil
+	}
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(b.r, buf); err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+// skipClientInfo mirrors proto.ClientInfo.DecodeAware field-for-field, with
+// bounded string reads, and returns the client's protocol version.
+func (b *chBoundedReader) skipClientInfo(version int) (int, error) {
+	r := b.r
+	kind, err := r.UInt8()
+	if err != nil {
+		return 0, err
+	}
+	if !proto.ClientQueryKind(kind).IsAClientQueryKind() {
+		return 0, io.ErrUnexpectedEOF
+	}
+	for i := 0; i < 3; i++ { // initial user, initial query id, initial address
+		if _, err := b.str(); err != nil {
+			return 0, err
+		}
+	}
+	if proto.FeatureQueryStartTime.In(version) {
+		if _, err := r.Int64(); err != nil {
+			return 0, err
+		}
+	}
+	iface, err := r.UInt8()
+	if err != nil {
+		return 0, err
+	}
+	if proto.Interface(iface) != proto.InterfaceTCP {
+		return 0, io.ErrUnexpectedEOF
+	}
+	for i := 0; i < 3; i++ { // os user, client hostname, client name
+		if _, err := b.str(); err != nil {
+			return 0, err
+		}
+	}
+	for i := 0; i < 2; i++ { // major, minor version
+		if _, err := r.Int(); err != nil {
+			return 0, err
+		}
+	}
+	protocolVersion, err := r.Int()
+	if err != nil {
+		return 0, err
+	}
+	if proto.FeatureQuotaKeyInClientInfo.In(version) {
+		if _, err := b.str(); err != nil {
+			return 0, err
+		}
+	}
+	if proto.FeatureDistributedDepth.In(version) {
+		if _, err := r.Int(); err != nil {
+			return 0, err
+		}
+	}
+	if proto.FeatureVersionPatch.In(version) {
+		if _, err := r.Int(); err != nil {
+			return 0, err
+		}
+	}
+	if proto.FeatureOpenTelemetry.In(version) {
+		hasTrace, err := r.Bool()
+		if err != nil {
+			return 0, err
+		}
+		if hasTrace {
+			if _, err := r.ReadRaw(16); err != nil { // trace id
+				return 0, err
+			}
+			if _, err := r.ReadRaw(8); err != nil { // span id
+				return 0, err
+			}
+			if _, err := b.str(); err != nil { // trace state
+				return 0, err
+			}
+			if _, err := r.Byte(); err != nil { // trace flags
+				return 0, err
+			}
+		}
+	}
+	if proto.FeatureParallelReplicas.In(version) {
+		for i := 0; i < 3; i++ { // collaborate with initiator, participating replicas, current replica
+			if _, err := r.Int(); err != nil {
+				return 0, err
+			}
+		}
+	}
+	return protocolVersion, nil
+}
+
+func (b *chBoundedReader) skipSettings() error {
+	for {
+		key, err := b.str()
+		if err != nil {
+			return err
+		}
+		if key == "" {
+			return nil
+		}
+		if _, err := b.r.UVarInt(); err != nil {
+			return err
+		}
+		if _, err := b.str(); err != nil {
+			return err
+		}
+	}
+}
 
 func ParseClickhouse(payload []byte) (query string) {
 	defer func() {
@@ -14,35 +148,29 @@ func ParseClickhouse(payload []byte) (query string) {
 		}
 	}()
 	r := proto.NewReader(bytes.NewReader(payload))
+	b := &chBoundedReader{r: r, max: len(payload)}
 	var err error
 	if _, err = r.Byte(); err != nil {
 		return ""
 	}
-	if _, err = r.Str(); err != nil {
+	if _, err = b.str(); err != nil { // query id
 		return ""
 	}
 	version := int(proto.FeatureServerQueryTimeInProgress)
-	info := proto.ClientInfo{}
-	if err = info.DecodeAware(r, version); err != nil {
+	protocolVersion, err := b.skipClientInfo(version)
+	if err != nil {
 		return ""
 	}
-	if info.ProtocolVersion > 0 {
-		if info.ProtocolVersion > version {
+	if protocolVersion > 0 {
+		if protocolVersion > version {
 			return ""
 		}
-		version = info.ProtocolVersion
+		version = protocolVersion
 	}
-	var s proto.Setting
-
-	for {
-		if err = s.Decode(r); err != nil {
-			return ""
-		}
-		if s.Key == "" {
-			break
-		}
+	if err = b.skipSettings(); err != nil {
+		return ""
 	}
-	if _, err = r.Str(); err != nil { // inter-server secret
+	if _, err = b.str(); err != nil { // inter-server secret
 		return ""
 	}
 	if stage, err := r.UVarInt(); err != nil { // stage

--- a/ebpftracer/l7/l7_test.go
+++ b/ebpftracer/l7/l7_test.go
@@ -3,6 +3,7 @@ package l7
 import (
 	"bytes"
 	"encoding/binary"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -282,4 +283,38 @@ func TestParseZookeeper(t *testing.T) {
 
 	assert.Equal(t, "getData", op)
 	assert.Equal(t, "/clickhouse/tables/shard-1/coroot_3kuq8b3z/otel_t...<TRUNCATED>", arg)
+}
+
+// A misparse of a truncated capture can read garbage bytes as a huge string
+// length; ch-go allocates it before noticing. Each payload here claims a 4GiB
+// string in a few bytes.
+func TestParseClickhouseGarbageLength(t *testing.T) {
+	huge := make([]byte, binary.MaxVarintLen64)
+	huge = huge[:binary.PutUvarint(huge, 1<<32)] // claims a 4GiB string
+
+	str := func(s string) []byte {
+		b := make([]byte, binary.MaxVarintLen64)
+		b = b[:binary.PutUvarint(b, uint64(len(s)))]
+		return append(b, s...)
+	}
+
+	payloads := map[string][]byte{
+		// packet type, then the query id claims 4GiB
+		"query id": append([]byte{0x1}, huge...),
+		// packet type, valid query id, ClientInfo{kind, then initial user claims 4GiB}
+		"client info str": append(append(append([]byte{0x1}, str("q-1")...), 0x1), huge...),
+	}
+
+	for name, payload := range payloads {
+		t.Run(name, func(t *testing.T) {
+			var before, after runtime.MemStats
+			runtime.GC()
+			runtime.ReadMemStats(&before)
+			assert.Equal(t, "", ParseClickhouse(payload))
+			runtime.ReadMemStats(&after)
+			allocated := after.TotalAlloc - before.TotalAlloc
+			assert.Lessf(t, allocated, uint64(1<<20),
+				"ParseClickhouse allocated %d bytes for a %d-byte garbage payload", allocated, len(payload))
+		})
+	}
 }


### PR DESCRIPTION
## Problem

`ParseClickhouse` feeds a **truncated, untrusted** eBPF payload capture into ch-go's protocol decoder. ch-go's `Reader.Str` (via `Buffer.Ensure`) allocates `make([]byte, n)` from the decoded varint length prefix **before** validating `n` against the bytes actually available — it only checks `n >= 0`.

Against a well-behaved ClickHouse server that's harmless. Against a truncated capture, misaligned parses are routine — especially when the wire format is newer than the vendored ch-go v0.62.0 understands (we run ClickHouse 26.x) — and garbage bytes get read as a multi-gigabyte string length. The allocation fires even though the read then immediately fails; the `recover()` catches panics, not allocations.

## Production impact

On our EKS cluster the agent **OOM-crash-looped on every node hosting ClickHouse native-protocol clients**, dying at any memory limit we tried (1Gi → 8Gi, up to 9 kills per pod, one 59-second life). Heap profile of a dying agent (Coroot's own Go heap profiling):

```
total                                                    (3.0 GB, 100%)
containers.(*Registry).handleEvents                      (2.2 GB,  72%)
  containers.(*Container).onL7Request
    ebpftracer/l7.ParseClickhouse
      ch-go/proto.(*Setting).Decode
        ch-go/proto.(*Reader).Str → StrAppend → StrRaw   ← make([]byte, n), n unvalidated
```

Nodes without CH clients ran flat at ~400Mi throughout. This is very likely the cause of #242 as well (undiagnosed OOM against a 9GB limit).

## Fix

Replace the ch-go `ClientInfo.DecodeAware` / `Setting.Decode` calls with a field-identical bounded walk (same field order, same version feature gates, using ch-go's exported primitives and feature constants): every length-prefixed read is checked against the payload size before allocating. A claimed length beyond the capture is a misparse by construction.

- Well-formed frames parse exactly as before — the existing `TestParseClickHouse` payloads pass unchanged
- The new `TestParseClickhouseGarbageLength` demonstrates the bug: a **6-byte** payload that previously allocated **4.3GB** (measured via `runtime.MemStats` in the test) now allocates nothing

The deeper fix belongs in ch-go (`StrRaw` should validate the length against the source before `Ensure`), but bounding at this untrusted boundary is correct regardless of what ch-go does, and keeps the agent safe against any future protocol drift.

Happy to adjust the approach if you'd prefer a different shape (e.g. a max-string-length constant instead of the payload-size bound).
